### PR TITLE
Add ConverterCPR module for CPR data conversion

### DIFF
--- a/crocolaketools/converter/converterCPR.py
+++ b/crocolaketools/converter/converterCPR.py
@@ -5,7 +5,7 @@
 #
 ## @author David Nady <davidnady4yad@gmail.com>
 #
-## @date Fri 21 Mar 2025
+# @date Fri 21 Mar 2025
 
 ##########################################################################
 import os
@@ -98,7 +98,6 @@ class ConverterCPR(Converter):
         if 'PLATFORM_NUMBER' in df.columns:
             df['PLATFORM_NUMBER'] = df['PLATFORM_NUMBER'].astype('string')
 
-        # Standardize data using the parent class method
         df = super().standardize_data(df)
 
         return df

--- a/crocolaketools/converter/converterCPR.py
+++ b/crocolaketools/converter/converterCPR.py
@@ -2,26 +2,30 @@
 
 ## @file converterCPR.py
 #
-# @brief Converts CPR (Continuous Plankton Recorder) data to the CrocoLake format.
 #
-# @author David Nady <davidnady4yad@gmail.com>
+## @author David Nady <davidnady4yad@gmail.com>
 #
-# @date Sat 1 Mar 2025
+## @date Fri 21 Mar 2025
 
 ##########################################################################
 import os
 import warnings
-import dask.dataframe as dd
-from dask.distributed import Lock
+import logging
 import pandas as pd
-import numpy as np
-from crocolaketools.utils import params
+from crocolakeloader import params
 from crocolaketools.converter.converter import Converter
-
 ##########################################################################
 
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 class ConverterCPR(Converter):
-    """class ConverterCPR: methods to generate parquet schemas for CPR data."""
+
+    """class ConverterCPR: methods to generate parquet schemas for
+    Continuous Plankton Recorder (CPR) database
+
+    """
 
     # ------------------------------------------------------------------ #
     # Constructors/Destructors                                           #
@@ -30,84 +34,75 @@ class ConverterCPR(Converter):
     def __init__(self, db=None, db_type=None, input_path=None, outdir_pq=None, outdir_schema=None, fname_pq=None, add_derived_vars=False, overwrite=False):
         if not db == "CPR":
             raise ValueError("Database must be CPR.")
-        super().__init__(db, db_type, input_path, outdir_pq, outdir_schema, fname_pq, add_derived_vars, overwrite)
+        Converter.__init__(self, db, db_type, input_path, outdir_pq, outdir_schema, fname_pq, add_derived_vars, overwrite)
 
     # ------------------------------------------------------------------ #
     # Methods                                                            #
     # ------------------------------------------------------------------ #
 
     def read_to_df(self, filename=None, lock=None):
-        """
-        Read CPR data from a CSV file into a Pandas DataFrame.
+        """Read file into a pandas dataframe
 
-        Arguments:
-        filename -- path to the CPR data file
-        lock     -- optional lock for thread-safe file reading
+        Argument:
+        filename -- file name, including relative path
 
-        Returns:
-        df -- Pandas DataFrame containing the CPR data
+        Returns
+        df -- pandas dataframe
         """
+
         if filename is None:
-            filename = "765141_v5_cpr-plankton-abundance.csv"
+            raise ValueError("No filename provided for CPR database.")
 
-        input_fname = os.path.join(self.input_path, filename)
-        print(f"Reading CPR file: {input_fname}")
+        input_fname = self.input_path + filename
+        logger.info(f"Reading CPR file: {input_fname}")
 
-        df = pd.read_csv(input_fname)
+        try:
+            # Read the CSV file
+            df = pd.read_csv(input_fname, delimiter=",", header=0, low_memory=False)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"File not found: {input_fname}")
+        except pd.errors.EmptyDataError:
+            raise ValueError(f"File is empty: {input_fname}")
+        except pd.errors.ParserError:
+            raise ValueError(f"Unable to parse file: {input_fname}")
 
-        # Convert MidPoint_Date_UTC to a datetime object
-        df["MidPoint_Date_UTC"] = pd.to_datetime(df["MidPoint_Date_UTC"])
-
-        df = self.standardize_data(df)
-
-        return df
+        return self.standardize_data(df)
 
     def standardize_data(self, df):
-        """
-        Standardize the CPR data to the TRITON format.
+        """Standardize pandas dataframe to schema consistent across databases
 
-        Arguments:
-        df -- Pandas DataFrame containing the CPR data
+        Argument:
+        df -- pandas dataframe
 
         Returns:
-        df -- Standardized Pandas DataFrame
+        df -- homogenized dataframe
         """
-        # Rename columns using the CPR2TRITON mapping
-        rename_map = params.params["CPR2TRITON"]
-        df = df.rename(columns=rename_map)
 
-        # Ensure the data types are correct
-        df["LATITUDE"] = df["LATITUDE"].astype("float64")
-        df["LONGITUDE"] = df["LONGITUDE"].astype("float64")
-        df["JULD"] = df["JULD"].dt.tz_localize(None)  # Remove timezone informationa
-        df["JULD"] = df["JULD"].astype("datetime64[ns]")
+        # Rename columns using CPR2TRITON mapping
+        df = df.rename(columns=params.params["CPR2TRITON"])
 
-        # Add derived variables (if needed)
-        if self.add_derived_vars:
-            df = self.add_derived_variables(df)
+        # Convert CPR date column to datetime
+        logger.info("Converting CPR date column to datetime")
+        if 'JULD' in df.columns:
+            df['JULD'] = pd.to_datetime(df['JULD'])
+        elif all(col in df.columns for col in ['Year', 'Month', 'Day', 'Hour']):
+            df['JULD'] = pd.to_datetime(df[['Year', 'Month', 'Day', 'Hour']])
+        else:
+            warnings.warn("No valid date columns found. Unable to construct 'JULD'.")
+
+        # Ensure data types match the Triton schema
+        if 'LATITUDE' in df.columns:
+            df['LATITUDE'] = df['LATITUDE'].astype('float32')
+        if 'LONGITUDE' in df.columns:
+            df['LONGITUDE'] = df['LONGITUDE'].astype('float32')
+        if 'PLATFORM_NUMBER' in df.columns:
+            df['PLATFORM_NUMBER'] = df['PLATFORM_NUMBER'].astype('string')
+
+        # Standardize data using the parent class method
+        df = super().standardize_data(df)
 
         return df
 
-    def add_derived_variables(self, df):
-        """
-        Add derived variables to the DataFrame.
-
-        Arguments:
-        df -- Pandas DataFrame containing the CPR data
-
-        Returns:
-        df -- DataFrame with derived variables added
-        """
-        # Create a copy to avoid modifying the input DataFrame
-        df_with_derived = df.copy()
-
-        # Columns starting with PLANKTON_ contain individual plankton counts (id)
-        plankton_columns = [col for col in df.columns if col.startswith("PLANKTON_")]
-        df_with_derived["TOTAL_PLANKTON"] = df[plankton_columns].fillna(0).sum(axis=1)
-
-        return df_with_derived
-
 ##########################################################################
-
 if __name__ == "__main__":
     ConverterCPR()

--- a/crocolaketools/converter/converterCPR.py
+++ b/crocolaketools/converter/converterCPR.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+## @file converterCPR.py
+#
+# @brief Converts CPR (Continuous Plankton Recorder) data to the CrocoLake format.
+#
+# @author David Nady <davidnady4yad@gmail.com>
+#
+# @date Sat 1 Mar 2025
+
+##########################################################################
+import os
+import warnings
+import dask.dataframe as dd
+from dask.distributed import Lock
+import pandas as pd
+import numpy as np
+from crocolaketools.utils import params
+from crocolaketools.converter.converter import Converter
+
+##########################################################################
+
+class ConverterCPR(Converter):
+    """class ConverterCPR: methods to generate parquet schemas for CPR data."""
+
+    # ------------------------------------------------------------------ #
+    # Constructors/Destructors                                           #
+    # ------------------------------------------------------------------ #
+
+    def __init__(self, db=None, db_type=None, input_path=None, outdir_pq=None, outdir_schema=None, fname_pq=None, add_derived_vars=False, overwrite=False):
+        if not db == "CPR":
+            raise ValueError("Database must be CPR.")
+        super().__init__(db, db_type, input_path, outdir_pq, outdir_schema, fname_pq, add_derived_vars, overwrite)
+
+    # ------------------------------------------------------------------ #
+    # Methods                                                            #
+    # ------------------------------------------------------------------ #
+
+    def read_to_df(self, filename=None, lock=None):
+        """
+        Read CPR data from a CSV file into a Pandas DataFrame.
+
+        Arguments:
+        filename -- path to the CPR data file
+        lock     -- optional lock for thread-safe file reading
+
+        Returns:
+        df -- Pandas DataFrame containing the CPR data
+        """
+        if filename is None:
+            filename = "765141_v5_cpr-plankton-abundance.csv"
+
+        input_fname = os.path.join(self.input_path, filename)
+        print(f"Reading CPR file: {input_fname}")
+
+        df = pd.read_csv(input_fname)
+
+        # Convert MidPoint_Date_UTC to a datetime object
+        df["MidPoint_Date_UTC"] = pd.to_datetime(df["MidPoint_Date_UTC"])
+
+        df = self.standardize_data(df)
+
+        return df
+
+    def standardize_data(self, df):
+        """
+        Standardize the CPR data to the TRITON format.
+
+        Arguments:
+        df -- Pandas DataFrame containing the CPR data
+
+        Returns:
+        df -- Standardized Pandas DataFrame
+        """
+        # Rename columns using the CPR2TRITON mapping
+        rename_map = params.params["CPR2TRITON"]
+        df = df.rename(columns=rename_map)
+
+        # Ensure the data types are correct
+        df["LATITUDE"] = df["LATITUDE"].astype("float64")
+        df["LONGITUDE"] = df["LONGITUDE"].astype("float64")
+        df["JULD"] = df["JULD"].dt.tz_localize(None)  # Remove timezone informationa
+        df["JULD"] = df["JULD"].astype("datetime64[ns]")
+
+        # Add derived variables (if needed)
+        if self.add_derived_vars:
+            df = self.add_derived_variables(df)
+
+        return df
+
+    def add_derived_variables(self, df):
+        """
+        Add derived variables to the DataFrame.
+
+        Arguments:
+        df -- Pandas DataFrame containing the CPR data
+
+        Returns:
+        df -- DataFrame with derived variables added
+        """
+        # Create a copy to avoid modifying the input DataFrame
+        df_with_derived = df.copy()
+
+        # Columns starting with PLANKTON_ contain individual plankton counts (id)
+        plankton_columns = [col for col in df.columns if col.startswith("PLANKTON_")]
+        df_with_derived["TOTAL_PLANKTON"] = df[plankton_columns].fillna(0).sum(axis=1)
+
+        return df_with_derived
+
+##########################################################################
+
+if __name__ == "__main__":
+    ConverterCPR()

--- a/crocolaketools/test/test_converter.py
+++ b/crocolaketools/test/test_converter.py
@@ -891,7 +891,7 @@ class TestConverter:
         """
         converter = ConverterCPR(
             db="CPR",
-            db_type="PHY",
+            db_type="BGC",
             input_path=cpr_path,
             outdir_pq=outdir_cpr_pqt,
             outdir_schema="./schemas/CPR/",
@@ -914,7 +914,7 @@ class TestConverter:
         """
         converter = ConverterCPR(
             db="CPR",
-            db_type="PHY",
+            db_type="BGC",
             input_path=cpr_path,
             outdir_pq=outdir_cpr_pqt,
             outdir_schema="./schemas/CPR/",
@@ -957,7 +957,7 @@ class TestConverter:
 
         converter = ConverterCPR(
             db="CPR",
-            db_type="PHY",
+            db_type="BGC",
             input_path=cpr_path,
             outdir_pq=outdir_cpr_pqt,
             outdir_schema="./schemas/CPR/",
@@ -968,7 +968,7 @@ class TestConverter:
         converter.convert(filenames="765141_v5_cpr-plankton-abundance.csv")  # Pass the filename here
 
         # Check that the output Parquet file exists
-        output_files = glob.glob(os.path.join(outdir_cpr_pqt, "test_cpr_PHY*.parquet"))
+        output_files = glob.glob(os.path.join(outdir_cpr_pqt, "test_cpr_BGC*.parquet"))
         assert len(output_files) > 0, "No output Parquet files found"
 
         # Read the first Parquet file and check its contents

--- a/crocolaketools/test/test_converter.py
+++ b/crocolaketools/test/test_converter.py
@@ -34,8 +34,8 @@ argo_bgc_path = '/vortexfs1/share/boom/users/enrico.milanese/myDatabases/1011_BG
 outdir_bgc_pqt =  '/vortexfs1/share/boom/users/enrico.milanese/myDatabases/1002_BGC_ARGO-QC-DEV/tests/'
 spray_path = ''
 outdir_spray_pqt = ''
-cpr_path = './dataset/'
-outdir_cpr_pqt = './dataset'
+cpr_path = 'D:\GSoC\Temp\crocolaketools-public\crocolaketools\\test\dataset\\'
+outdir_cpr_pqt = 'D:\GSoC\Temp\crocolaketools-public\crocolaketools\\test\output\\'
 
 # if not os.path.exists(outdir_phy_pqt):
 #     raise ValueError("PHY output directory does not exist.")

--- a/crocolaketools/test/test_converter.py
+++ b/crocolaketools/test/test_converter.py
@@ -34,8 +34,8 @@ argo_bgc_path = '/vortexfs1/share/boom/users/enrico.milanese/myDatabases/1011_BG
 outdir_bgc_pqt =  '/vortexfs1/share/boom/users/enrico.milanese/myDatabases/1002_BGC_ARGO-QC-DEV/tests/'
 spray_path = ''
 outdir_spray_pqt = ''
-cpr_path = 'D:\GSoC\Temp\crocolaketools-public\crocolaketools\\test\dataset\\'
-outdir_cpr_pqt = 'D:\GSoC\Temp\crocolaketools-public\crocolaketools\\test\output\\'
+cpr_path = ''
+outdir_cpr_pqt = ''
 
 # if not os.path.exists(outdir_phy_pqt):
 #     raise ValueError("PHY output directory does not exist.")

--- a/crocolaketools/utils/params.py
+++ b/crocolaketools/utils/params.py
@@ -21,7 +21,7 @@ databases_codenames = {}
 databases_codenames["ARGO"] = "ARGO" #"ARGO-CLOUD"
 databases_codenames["GLODAP"] = "GLODAP"#"GLODAP-DEV"
 databases_codenames["SprayGliders"] = "SPRAY"#"SPRAY-DEV"
-databases_codenames["CPR"] = "CPR"
+databases_codenames["CPR"] = "CPR"#"CPR-DEV"
 
 params = {}
 

--- a/crocolaketools/utils/params.py
+++ b/crocolaketools/utils/params.py
@@ -573,7 +573,7 @@ params['CPR'] = [
     'Year',
     'Month',
     'Day',
-    'Hour'
+    'Hour',
 ]
 
 #
@@ -583,7 +583,7 @@ params["CPR2TRITON"] = {
     'SampleId' : 'PLATFORM_NUMBER',
     'Latitude' : 'LATITUDE',
     'Longitude' : 'LONGITUDE',
-    'MidPoint_Date_UTC' : 'JULD'
+    'MidPoint_Date_UTC' : 'JULD',
 }
 
 #------------------------------------------------------------------------------#

--- a/crocolaketools/utils/params.py
+++ b/crocolaketools/utils/params.py
@@ -15,12 +15,13 @@
 #------------------------------------------------------------------------------#
 #
 # List of databases and their folder names
-databases = ["ARGO", "GLODAP", "SprayGliders"]
+databases = ["ARGO", "GLODAP", "SprayGliders", "CPR"]
 
 databases_codenames = {}
 databases_codenames["ARGO"] = "ARGO" #"ARGO-CLOUD"
 databases_codenames["GLODAP"] = "GLODAP"#"GLODAP-DEV"
 databases_codenames["SprayGliders"] = "SPRAY"#"SPRAY-DEV"
+databases_codenames["CPR"] = "CPR"
 
 params = {}
 
@@ -559,13 +560,38 @@ params["SprayGliders2TRITON"] = {
     'time': 'JULD',
 }
 
+#------------------------------------------------------------------------------#
+# CPR (Continuous Plankton Recorder)
+#
+# original names of parameters to keep
 
+params['CPR'] = [
+    'SampleId',
+    'Latitude',
+    'Longitude',
+    'MidPoint_Date_UTC',
+    'Year',
+    'Month',
+    'Day',
+    'Hour'
+]
+
+#
+# dict for renaming parameters to triton names
+#
+params["CPR2TRITON"] = {
+    'SampleId' : 'PLATFORM_NUMBER',
+    'Latitude' : 'LATITUDE',
+    'Longitude' : 'LONGITUDE',
+    'MidPoint_Date_UTC' : 'JULD'
+}
 
 #------------------------------------------------------------------------------#
 # Argo
 #
 # standardized names for Argo only databases, when converting from GDAC
 #
+
 params["ArgoPHY"] = [
     'PLATFORM_NUMBER',
     'N_PROF',

--- a/crocolaketools/utils/params.py
+++ b/crocolaketools/utils/params.py
@@ -573,7 +573,7 @@ params['CPR'] = [
     'Year',
     'Month',
     'Day',
-    'Hour',
+    'Hour'
 ]
 
 #
@@ -583,7 +583,7 @@ params["CPR2TRITON"] = {
     'SampleId' : 'PLATFORM_NUMBER',
     'Latitude' : 'LATITUDE',
     'Longitude' : 'LONGITUDE',
-    'MidPoint_Date_UTC' : 'JULD',
+    'MidPoint_Date_UTC' : 'JULD'
 }
 
 #------------------------------------------------------------------------------#

--- a/scripts/cpr2parquet.py
+++ b/scripts/cpr2parquet.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+## @file cpr2parquet.py
+#
+#
+## @author David Nady <davidnady4yad@gmail.com>
+#
+## @date Fri 21 Mar 2025
+
+##########################################################################
+import os
+import argparse
+from pprint import pprint
+from warnings import simplefilter
+from datetime import datetime
+import pandas as pd
+# ignore pandas "educational" performance warnings
+simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
+from crocolaketools.converter.converterCPR import ConverterCPR
+##########################################################################
+
+def cpr2parquet(cpr_path, cpr_name, outdir_pqt_phy, outdir_pqt_bgc, fname_pq):
+    """Convert CPR data to parquet format"""
+
+    ConverterPHY = ConverterCPR(
+        db = "CPR",
+        db_type="PHY",
+        input_path = cpr_path,
+        outdir_pq = outdir_pqt_phy,
+        outdir_schema = './schemas/CPR/',
+        fname_pq = fname_pq,
+        add_derived_vars = True
+    )
+
+    ConverterPHY.convert(cpr_name)
+
+    del ConverterPHY
+
+    ConverterBGC = ConverterCPR(
+        db = "CPR",
+        db_type="BGC",
+        input_path = cpr_path,
+        outdir_pq = outdir_pqt_bgc,
+        outdir_schema = './schemas/CPR/',
+        fname_pq = fname_pq,
+        add_derived_vars = True
+    )
+
+    ConverterBGC.convert(cpr_name)
+
+    del ConverterBGC
+
+    return
+
+#------------------------------------------------------------------------------#
+def main():
+    parser = argparse.ArgumentParser(description='Script to convert CPR csv file to parquet')
+    parser.add_argument('-i', help="Path to CPR csv file", required=True)
+    parser.add_argument('-n', help="Name of CPR csv file", required=True)
+    parser.add_argument('--phy', help="Destination path for physical-variables database", required=True)
+    parser.add_argument('--bgc', help="Destination path for bgc-variables database", required=True)
+    parser.add_argument('-b', help="Basename for output files", required=False, default="CPR")
+
+    args = parser.parse_args()
+
+    cpr2parquet(args.i, args.n, args.phy, args.bgc, args.b)
+
+##########################################################################
+
+if __name__ == "__main__":
+    print(datetime.now())
+    print()
+    main()
+    print("cpr2parquet.py executed successfully")
+    print()
+    print(datetime.now())
+    print(" ")

--- a/scripts/cpr2parquet.py
+++ b/scripts/cpr2parquet.py
@@ -5,7 +5,7 @@
 #
 ## @author David Nady <davidnady4yad@gmail.com>
 #
-## @date Fri 21 Mar 2025
+# @date Fri 21 Mar 2025
 
 ##########################################################################
 import os


### PR DESCRIPTION
This PR introduces the ConverterCPR module, designed to help convert CPR (Continuous Plankton Recorder) data into the CrocoLake format. Here’s a quick rundown of what’s been added:

### Key Features:
✅ **Implemented `converterCPR.py`** – A new module for seamless CPR data conversion, ensuring smooth integration with CrocoLake.  
✅ **Added `read_to_df()`** – Reads CPR data from a CSV file, converts timestamps, and prepares it for processing.  
✅ **Implemented `standardize_data()`** – Renames columns based on the `CPR2TRITON` mapping and ensures correct data types.  
✅ **Added Test Cases**:  
   - `test_converter_cpr_read_to_df`: Validates CPR CSV file loading.  
   - `test_converter_cpr_standardize_data`: Ensures correct data standardization.  
   - `test_converter_cpr_convert`: Verifies conversion from CSV to Parquet format.  

✅ **Updated `params.py`** – Added original parameter names alongside standardized ones for full compatibility.

📌Note: In `test_converter`, make sure to set `cpr_path` and `outdir_cpr_pqt`. If you encounter issues reading or writing files, try using a relative path, e.g., `C:\Users\John\datasets\`.

You can run the tests with the following command (don’t forget to set the `cpr_path` and `outdir_cpr_pqt` parameters first):

```bash
pytest crocolaketools/test/test_converter.py -k "test_converter_cpr"
```
The output will be a Parquet file (e.g., `test_cpr_BGC_000.parquet`) containing data with the fields: `DB_NAME`, `PLATFORM_NUMBER`, `LATITUDE`, `LONGITUDE`, and `JULD`.

As always, feel free to give feedback.