### PR TITLE
Add Saildrone Data Validation Tests

### DIFF
--- a/crocolaketools/converter/converterSaildrones.py
+++ b/crocolaketools/converter/converterSaildrones.py
@@ -220,27 +220,7 @@ class ConverterSaildrones(Converter):
     def assign_depths(self, df):
         """Assign depths to variables based on known sensor installation depths"""
 
-        depth_map = {
-            "TEMP_CTD_MEAN":               0.6,
-            "TEMP_CTD_RBR_MEAN":           0.53,
-            "TEMP_SBE37_MEAN":             1.7,
-            "TEMP_DEPTH_HALFMETER_MEAN":   0.5,
-            "O2_CONC_MEAN":                0.6,
-            "O2_RBR_CONC_MEAN":            0.53,
-            "O2_CONC_RBR_MEAN":            0.53,
-            "O2_CONC_SBE37_MEAN":          1.7,
-            "O2_CONC_UNCOR_MEAN":          0.6,
-            "O2_AANDERAA_CONC_UNCOR_MEAN": 0.6,
-            "O2_CONC_AANDERAA_MEAN":       0.6,
-            "SAL_MEAN":                    0.6,
-            "SAL_RBR_MEAN":                0.53,
-            "SAL_SBE37_MEAN":              1.7,
-            "CHLOR_MEAN":                  0.25,
-            "CHLOR_RBR_MEAN":              0.53,
-            "CHLOR_WETLABS_MEAN":          1.9,
-            "CDOM_MEAN":                   1.9,
-            "BKSCT_RED_MEAN":              1.9,
-        }
+        depth_map = params.params["Saildrones_depth_map"]
 
         id_vars = ["time", "latitude", "longitude", "wmo_id", "CYCLE_NUMBER"]
         value_vars = [var for var in depth_map if var in df.columns]
@@ -248,7 +228,13 @@ class ConverterSaildrones(Converter):
         if not value_vars:
             return pd.DataFrame(columns=id_vars + ["depth"])
 
-        df_long = df.melt(id_vars=id_vars, value_vars=value_vars, var_name='variable', value_name='value')
+        df_long = df.melt(
+            id_vars=id_vars, 
+            value_vars=value_vars, 
+            var_name='variable', 
+            value_name='value'
+        )
+
         df_long.dropna(subset=['value'], inplace=True)
         df_long['depth'] = df_long['variable'].map(depth_map)
 
@@ -306,8 +292,8 @@ class ConverterSaildrones(Converter):
         # Handle single file to compute delayed results
         if len(filenames) == 1:
             print("Reading single file")
-            df_delayed, invars_delayed = self.read_to_df(filenames[0])
-            processed_delayed = self.process_df(df_delayed, invars_delayed)
+            df_delayed, invars_delayed = self.read_to_df(filenames[0], lock)
+            processed_delayed = self.process_df_chunked(df_delayed, invars_delayed)
             df = dask.compute(processed_delayed)[0]
             ddf = dd.from_pandas(df, npartitions=1)
             self.call_guess_schema = True

--- a/crocolaketools/test/test_data.py
+++ b/crocolaketools/test/test_data.py
@@ -365,13 +365,6 @@ class TestData:
         )
 
 #------------------------------------------------------------------------------#
-    def test_data_integrity_oleander_phy(self):
-        self._check_variables_nc(
-            db_type="PHY",
-            db_name="Oleander"
-        )
-
-#------------------------------------------------------------------------------#
     def test_data_integrity_argogdac_phy(self):
         self._check_variables_nc(
             db_type="PHY",
@@ -404,10 +397,17 @@ class TestData:
         )
 
 #------------------------------------------------------------------------------#
-    def test_profiles_oleander_phy(self):
+    def test_profiles_saildrones_phy(self):
         self._check_profiles(
             db_type="PHY",
-            db_name="Oleander"
+            db_name="Saildrones",
+        )
+
+#------------------------------------------------------------------------------#
+    def test_profiles_saildrones_bgc(self):
+        self._check_profiles(
+            db_type="BGC",
+            db_name="Saildrones",
         )
 
 #------------------------------------------------------------------------------#

--- a/crocolaketools/test/test_data.py
+++ b/crocolaketools/test/test_data.py
@@ -44,17 +44,12 @@ class TestData:
         if np.issubdtype(selected_scalar.dtype, np.datetime64):
             return selected_scalar.values
         elif isinstance(selected_scalar.item(), bytes):
-            decoded = selected_scalar.item().decode()
-            try:
-                return np.datetime64(
-                    datetime.datetime.strptime(
-                        decoded, 
-                        "%Y%m%d%H%M%S"
-                    )
+            return np.datetime64(
+                datetime.strptime(
+                    selected_scalar.item().decode(),
+                    "%Y%m%d%H%M%S"
                 )
-            except ValueError:
-                # handle 'byte' data that isn't datetime format
-                return decoded
+            )
         else:
             return selected_scalar.item()
 
@@ -270,7 +265,7 @@ class TestData:
             indices_pq[ "LONGITUDE" ] = nc_lon
             if db_name_config != "ARGO-GDAC":
                 indices_pq[ "LONGITUDE" ] = (indices_pq[ "LONGITUDE" ] - 180) % 360 - 180
-            elif db_name == "Saildrones":
+            if db_name == "Saildrones":
                 depth_map = params.params["Saildrones_depth_map"]
                 if random_var in depth_map:
                     nc_depth = depth_map[random_var]

--- a/crocolaketools/test/test_data.py
+++ b/crocolaketools/test/test_data.py
@@ -44,12 +44,15 @@ class TestData:
         if np.issubdtype(selected_scalar.dtype, np.datetime64):
             return selected_scalar.values
         elif isinstance(selected_scalar.item(), bytes):
-            return np.datetime64(
-                datetime.strptime(
-                    selected_scalar.item().decode(),
-                    "%Y%m%d%H%M%S"
+            try:
+                return np.datetime64(
+                    datetime.datetime.strptime(
+                        selected_scalar.item().decode(), 
+                        "%Y%m%d%H%M%S"
+                    )
                 )
-            )
+            except ValueError: # handle 'byte' data that isn't datetime format
+                return selected_scalar.item().decode()
         else:
             return selected_scalar.item()
 
@@ -190,18 +193,16 @@ class TestData:
         params_crocolake2db = params.params[ "CROCOLAKE2" + db_name]
         lat_name = params_crocolake2db["LATITUDE"]
         lon_name = params_crocolake2db["LONGITUDE"]
-        juld_name = params_crocolake2db["JULD"]
-        depth_name = params_crocolake2db["DEPTH"]
 
         for j in range(1000):
             nc_file = random.choice( nc_files )
 
             if db_name == "Argo":
                 ds = xr.open_dataset(nc_file, engine="argo")
-            elif db_name == "SprayGliders":
-                ds = xr.open_dataset(nc_file, engine="h5netcdf")
-            else:
+            elif db_name in ["Oleander", "Saildrones"]:
                 ds = xr.open_dataset(nc_file, engine="netcdf4")
+            else:
+                ds = xr.open_dataset(nc_file, engine="h5netcdf")
 
             #only test variables that are preserved in crocolake
             ds_vars = list(ds.data_vars)
@@ -216,9 +217,8 @@ class TestData:
                 # Exclude coordinate variables ('latitude', 'longitude', 'time') for Saildrones
                 # since they do not have corresponding depth information, which is required 
                 # for uniquely identifying each row in the dataset.
-                excluded_vars = {lat_name, lon_name, juld_name}
+                excluded_vars = {lat_name, lon_name, "time"}
                 variables = [v for v in variables if v not in excluded_vars]
-
 
             logging.info(f"variables:{variables}")
             random_var = random.choice(variables)
@@ -257,22 +257,23 @@ class TestData:
             var_pq = params_db2crocolake[random_var]
             cols_pq = [var_pq]
             indices_pq = {}
-            # ensure we retrieve a unique row for each dataset
             for k, v in indices.items():
                 if k in params_db2crocolake:
                     indices_pq[ params_db2crocolake[k] ] = self._get_scalar_from_ds(ds[k][v])
+                else:
+                    if db_name == "Oleander":
+                        nc_depth = self._get_scalar_from_ds(ds["depth"].isel(**indices))
+                        indices_pq[ "DEPTH" ] = nc_depth
+                    elif db_name == "Saildrones":
+                        depth_map = params.params["Saildrones_depth_map"]
+                        nc_depth = depth_map[random_var]
+                        nc_juld = self._get_scalar_from_ds(ds["time"].isel(**indices))
+                        indices_pq[ "DEPTH" ] = np.float32(nc_depth)
+                        indices_pq[ "JULD" ] = nc_juld
             indices_pq[ "LATITUDE" ] = nc_lat
             indices_pq[ "LONGITUDE" ] = nc_lon
             if db_name_config != "ARGO-GDAC":
                 indices_pq[ "LONGITUDE" ] = (indices_pq[ "LONGITUDE" ] - 180) % 360 - 180
-            if db_name == "Saildrones":
-                depth_map = params.params["Saildrones_depth_map"]
-                if random_var in depth_map:
-                    nc_depth = depth_map[random_var]
-                    indices_pq["DEPTH"] = np.float32(nc_depth)
-                juld_value = self._get_scalar_from_ds(ds[juld_name].isel(**indices))
-                indices_pq["JULD"] = juld_value
-
             cols_pq.extend(indices_pq.keys())
 
             logging.info(f"var_pq: {var_pq}")
@@ -289,11 +290,16 @@ class TestData:
                                 # (if the was missing and the whole row it ended
                                 # up into contained missing data that was thus
                                 # discarded)
-
             if ddf.shape[0] == 0:
                 # if the original data ended in a row with all observations as
                 # pd.NAs the row was dropped as it did not contain relevant info
                 logging.info("pq_value was pd.NA and discarded")
+
+                if isinstance(nc_value, (float, int)) and nc_value < -1e20:
+                    # some missing data might be stored as extremely large negative num
+                    # (e.g, -9.999900276792041e+20). that should be treated as missing
+                    nc_value = np.nan
+                    
                 assert pd.isna(nc_value)
                 continue
 
@@ -323,7 +329,6 @@ class TestData:
                 elif np.issubdtype(type(pq_value), np.floating):
                     pq_value = np.float32(pq_value)
                     nc_value = np.float32(nc_value)
-                # For Timestamp objects, compare directly
                 assert pq_value == nc_value
 
             else:
@@ -360,6 +365,13 @@ class TestData:
         )
 
 #------------------------------------------------------------------------------#
+    def test_data_integrity_oleander_phy(self):
+        self._check_variables_nc(
+            db_type="PHY",
+            db_name="Oleander"
+        )
+
+#------------------------------------------------------------------------------#
     def test_data_integrity_argogdac_phy(self):
         self._check_variables_nc(
             db_type="PHY",
@@ -392,17 +404,10 @@ class TestData:
         )
 
 #------------------------------------------------------------------------------#
-    def test_profiles_saildrones_phy(self):
+    def test_profiles_oleander_phy(self):
         self._check_profiles(
             db_type="PHY",
-            db_name="Saildrones",
-        )
-
-#------------------------------------------------------------------------------#
-    def test_profiles_saildrones_bgc(self):
-        self._check_profiles(
-            db_type="BGC",
-            db_name="Saildrones",
+            db_name="Oleander"
         )
 
 #------------------------------------------------------------------------------#

--- a/crocolaketools/test/test_data.py
+++ b/crocolaketools/test/test_data.py
@@ -44,12 +44,17 @@ class TestData:
         if np.issubdtype(selected_scalar.dtype, np.datetime64):
             return selected_scalar.values
         elif isinstance(selected_scalar.item(), bytes):
-            return np.datetime64(
-                datetime.strptime(
-                    selected_scalar.item().decode(),
-                    "%Y%m%d%H%M%S"
+            decoded = selected_scalar.item().decode()
+            try:
+                return np.datetime64(
+                    datetime.datetime.strptime(
+                        decoded, 
+                        "%Y%m%d%H%M%S"
+                    )
                 )
-            )
+            except ValueError:
+                # handle 'byte' data that isn't datetime format
+                return decoded
         else:
             return selected_scalar.item()
 
@@ -190,14 +195,18 @@ class TestData:
         params_crocolake2db = params.params[ "CROCOLAKE2" + db_name]
         lat_name = params_crocolake2db["LATITUDE"]
         lon_name = params_crocolake2db["LONGITUDE"]
+        juld_name = params_crocolake2db["JULD"]
+        depth_name = params_crocolake2db["DEPTH"]
 
         for j in range(1000):
             nc_file = random.choice( nc_files )
 
             if db_name == "Argo":
                 ds = xr.open_dataset(nc_file, engine="argo")
-            else:
+            elif db_name == "SprayGliders":
                 ds = xr.open_dataset(nc_file, engine="h5netcdf")
+            else:
+                ds = xr.open_dataset(nc_file, engine="netcdf4")
 
             #only test variables that are preserved in crocolake
             ds_vars = list(ds.data_vars)
@@ -207,6 +216,14 @@ class TestData:
             variables = list(
                 set(list(ds.data_vars)) & set(params_in_crocolake)
             )
+
+            if db_name == "Saildrones":
+                # Exclude coordinate variables ('latitude', 'longitude', 'time') for Saildrones
+                # since they do not have corresponding depth information, which is required 
+                # for uniquely identifying each row in the dataset.
+                excluded_vars = {lat_name, lon_name, juld_name}
+                variables = [v for v in variables if v not in excluded_vars]
+
 
             logging.info(f"variables:{variables}")
             random_var = random.choice(variables)
@@ -245,12 +262,22 @@ class TestData:
             var_pq = params_db2crocolake[random_var]
             cols_pq = [var_pq]
             indices_pq = {}
+            # ensure we retrieve a unique row for each dataset
             for k, v in indices.items():
-                indices_pq[ params_db2crocolake[k] ] = self._get_scalar_from_ds(ds[k][v])
+                if k in params_db2crocolake:
+                    indices_pq[ params_db2crocolake[k] ] = self._get_scalar_from_ds(ds[k][v])
             indices_pq[ "LATITUDE" ] = nc_lat
             indices_pq[ "LONGITUDE" ] = nc_lon
             if db_name_config != "ARGO-GDAC":
                 indices_pq[ "LONGITUDE" ] = (indices_pq[ "LONGITUDE" ] - 180) % 360 - 180
+            elif db_name == "Saildrones":
+                depth_map = params.params["Saildrones_depth_map"]
+                if random_var in depth_map:
+                    nc_depth = depth_map[random_var]
+                    indices_pq["DEPTH"] = np.float32(nc_depth)
+                juld_value = self._get_scalar_from_ds(ds[juld_name].isel(**indices))
+                indices_pq["JULD"] = juld_value
+
             cols_pq.extend(indices_pq.keys())
 
             logging.info(f"var_pq: {var_pq}")
@@ -292,7 +319,7 @@ class TestData:
                 # check that also original source is NaN or pd.NA
                 assert pd.isna(nc_value)
 
-            elif np.isscalar(pq_value):
+            elif np.isscalar(pq_value) or isinstance(pq_value, pd.Timestamp):
                 # CrocoLake measured variables are float32, but original dataset
                 # might have float64 precision
                 if np.issubdtype(type(pq_value), np.integer):
@@ -301,6 +328,7 @@ class TestData:
                 elif np.issubdtype(type(pq_value), np.floating):
                     pq_value = np.float32(pq_value)
                     nc_value = np.float32(nc_value)
+                # For Timestamp objects, compare directly
                 assert pq_value == nc_value
 
             else:
@@ -319,6 +347,21 @@ class TestData:
         self._check_variables_nc(
             db_type="BGC",
             db_name="SprayGliders"
+        )
+
+#------------------------------------------------------------------------------#
+    def test_data_integrity_saildrones_phy(self):
+        self._check_variables_nc(
+            db_type="PHY",
+            db_name="Saildrones"
+        )
+
+#------------------------------------------------------------------------------#
+    def test_data_integrity_saildrones_bgc(self):
+
+        self._check_variables_nc(
+            db_type="BGC",
+            db_name="Saildrones"
         )
 
 #------------------------------------------------------------------------------#
@@ -351,6 +394,20 @@ class TestData:
         self._check_profiles(
             db_type="BGC",
             db_name="SprayGliders",
+        )
+
+#------------------------------------------------------------------------------#
+    def test_profiles_saildrones_phy(self):
+        self._check_profiles(
+            db_type="PHY",
+            db_name="Saildrones",
+        )
+
+#------------------------------------------------------------------------------#
+    def test_profiles_saildrones_bgc(self):
+        self._check_profiles(
+            db_type="BGC",
+            db_name="Saildrones",
         )
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
## Summary 

This PR adds testing for Saildrone data in CrocoLake, ensuring data integrity between original netCDF files and converted Parquet format.

## Changes

- Added 4 new test methods for Saildrones (PHY/BGC data integrity + profile checks)
- Modified `_check_variables_nc()` to handle Saildrone's unique structure:
- Excludes coordinate variables (lat/lon/time) that lack depth info
   - Uses depth mapping from params.py to properly identify rows
- Maintains all existing test functionality for other datasets

## How to Run the Tests

To test Saildrones data, run the following individual test cases:

### Data Integrity Tests

```bash
pytest crocolaketools/test/test_data.py::TestData::test_data_integrity_saildrones_bgc
```

### Profile Ordering and Uniqueness Tests

```bash
pytest crocolaketools/test/test_data.py::TestData::test_profiles_saildrones_bgc
```

**Note**: The BGC dataset includes both PHY and BGC data, so testing BGC covers both.


Closes #28