### PR TITLE
fix: do not assign QC flags to null values in add_qc_flags

### DIFF
--- a/crocolaketools/converter/converter.py
+++ b/crocolaketools/converter/converter.py
@@ -756,7 +756,7 @@ class Converter:
             else:
                 raise ValueError("QC value must be an integer or a list of integers.")
 
-            df[param_qc] = qc
+            df[param_qc] = df[param].apply(lambda x: qc if pd.notna(x) else pd.NA)
             df[param_qc] = df[param_qc].astype("uint8[pyarrow]")
 
             if param_qc not in self.schema_pq.names:


### PR DESCRIPTION
### Description

This PR fixes issue #14 by ensuring that QC flags are not assigned to rows where the target column contains null (`<NA>`) values.

### Problem

The `add_qc_flags()` method in `converter.py` was assigning QC flags indiscriminately, including to rows where the data values were missing (`<NA>`). This was unintended behavior because missing values should not be considered "good quality."

### Solution

Added a condition to skip assigning QC flags where the value is null.

### Related Issue

Closes #14 
