### PR TITLE
Fix #35: Correct Saildrones oxygen unit conversion (µmol/L >> µmol/kg)

### DIFF
--- a/crocolaketools/converter/converter.py
+++ b/crocolaketools/converter/converter.py
@@ -22,7 +22,7 @@ import pyarrow.parquet as pq
 import shutil
 import xarray as xr
 from crocolakeloader import params
-from crocolaketools.converter import unit_converter
+from crocolaketools.converter import units_conversion
 ##########################################################################
 
 
@@ -831,11 +831,15 @@ class Converter:
         for col, conversion_key in self.cols_to_convert.items():
             if conversion_key == "skip":
                 continue
-            if conversion_key not in unit_converter.conversion_map:
+            if conversion_key not in units_conversion.conversion_map:
                 raise ValueError(f"No conversion defined for '{conversion_key}'")
-            if col not in ddf.columns: # column not found in df - skipping
+            if col not in ddf.columns:
+                is_expected = col in self.reference_schema.names
+                if is_expected:
+                    raise ValueError(f"Expected column '{col}' not found in dataframe. This may indicate a typo or missing variable.")
+                # column is not expected in the db_type, so skip conversion
                 continue
-            convert_fn = unit_converter.conversion_map[conversion_key]
+            convert_fn = units_conversion.conversion_map[conversion_key]
             ddf = convert_fn(ddf, col)
 
         return ddf

--- a/crocolaketools/converter/converter.py
+++ b/crocolaketools/converter/converter.py
@@ -834,8 +834,7 @@ class Converter:
             if conversion_key not in units_conversion.conversion_map:
                 raise ValueError(f"No conversion defined for '{conversion_key}'")
             if col not in ddf.columns:
-                is_expected = col in self.reference_schema.names
-                if is_expected:
+                if col in self.reference_schema.names:
                     raise ValueError(f"Expected column '{col}' not found in dataframe. This may indicate a typo or missing variable.")
                 # column is not expected in the db_type, so skip conversion
                 continue

--- a/crocolaketools/converter/converter.py
+++ b/crocolaketools/converter/converter.py
@@ -246,6 +246,8 @@ class Converter:
             print("adding derived variables")
             ddf = self.add_derived_variables(ddf)
 
+        ddf = self.convert_units(ddf)
+
         ddf = self.reorder_columns(ddf)
 
         ddf = ddf.drop_duplicates()
@@ -809,6 +811,20 @@ class Converter:
         )
 
         return df
+
+#------------------------------------------------------------------------------#
+## Convert units
+    def convert_units(self, ddf):
+        """Template method for unit conversions.
+        Override in subclasses that need specific unit conversions.
+        
+        Arguments:
+        ddf -- dask dataframe
+        
+        Returns:
+        ddf -- updated dask dataframe with converted units
+        """
+        return ddf
 
 #------------------------------------------------------------------------------#
 ## Update columns

--- a/crocolaketools/converter/converter.py
+++ b/crocolaketools/converter/converter.py
@@ -22,6 +22,7 @@ import pyarrow.parquet as pq
 import shutil
 import xarray as xr
 from crocolakeloader import params
+from crocolaketools.converter import unit_converter
 ##########################################################################
 
 
@@ -173,6 +174,9 @@ class Converter:
         # This should be false unless you're using from_delayed to generate the
         # dask dataframe
         self.call_guess_schema = False
+
+        # Initialize unit conversion mapping - override in subclasses
+        self.cols_to_convert = {"skip": "skip"}
 
     # ------------------------------------------------------------------ #
     # Methods                                                            #
@@ -815,8 +819,7 @@ class Converter:
 #------------------------------------------------------------------------------#
 ## Convert units
     def convert_units(self, ddf):
-        """Template method for unit conversions.
-        Override in subclasses that need specific unit conversions.
+        """Apply unit conversions defined in self.cols_to_convert.
         
         Arguments:
         ddf -- dask dataframe
@@ -824,6 +827,17 @@ class Converter:
         Returns:
         ddf -- updated dask dataframe with converted units
         """
+
+        for col, conversion_key in self.cols_to_convert.items():
+            if conversion_key == "skip":
+                continue
+            if conversion_key not in unit_converter.conversion_map:
+                raise ValueError(f"No conversion defined for '{conversion_key}'")
+            if col not in ddf.columns: # column not found in df - skipping
+                continue
+            convert_fn = unit_converter.conversion_map[conversion_key]
+            ddf = convert_fn(ddf, col)
+
         return ddf
 
 #------------------------------------------------------------------------------#

--- a/crocolaketools/converter/converterSaildrones.py
+++ b/crocolaketools/converter/converterSaildrones.py
@@ -275,6 +275,41 @@ class ConverterSaildrones(Converter):
         return df
 
 #------------------------------------------------------------------------------#
+## Convert units
+    def convert_units(self, ddf):
+        """Convert DOXY from μmol/L to μmol/kg using seawater density."""
+        
+        if 'DOXY' not in ddf.columns:
+            return ddf
+        
+        if not self.add_derived_vars:
+            raise ValueError(
+                    "DOXY unit conversion requires derived variables "
+                    "Set add_derived_vars=True to enable unit conversion."
+                )
+        
+        # Ensure required derived columns exist (should be added if add_derived_vars=True)
+        required_cols = ['ABS_SAL_COMPUTED', 'CONSERVATIVE_TEMP_COMPUTED']
+        missing = [col for col in required_cols if col not in ddf.columns]
+        if missing:
+            raise RuntimeError(f"Missing required columns for DOXY conversion: {missing_cols}.")
+        
+        def convert_doxy_partition(df):
+            # convert DOXY units in a single partition.
+            sigma0 = gsw.density.sigma0(df['ABS_SAL_COMPUTED'], df['CONSERVATIVE_TEMP_COMPUTED'])
+            correction_factor = sigma0 / 1000 + 1
+            df['DOXY'] = df['DOXY'] / correction_factor
+            return df
+        
+        print("Converting DOXY from μmol/L to μmol/kg")
+        ddf = ddf.map_partitions(
+            convert_doxy_partition, 
+            meta=ddf._meta
+        )
+        
+        return ddf
+
+#------------------------------------------------------------------------------#
 ## Convert file
     def convert(self, filenames=None, filepath=None):
         """Override convert to handle single file to compute delayed operations, 

--- a/crocolaketools/converter/converterSaildrones.py
+++ b/crocolaketools/converter/converterSaildrones.py
@@ -45,6 +45,12 @@ class ConverterSaildrones(Converter):
 
         super().__init__(config)
 
+        # define unit conversions for Saildrones
+        # DOXY is provided in μmol/L and must become μmol/kg
+        self.cols_to_convert = {
+            "DOXY": "micromol/L2micromol/kg"
+        }
+
     # ------------------------------------------------------------------ #
     # Methods                                                            #
     # ------------------------------------------------------------------ #
@@ -275,41 +281,6 @@ class ConverterSaildrones(Converter):
         return df
 
 #------------------------------------------------------------------------------#
-## Convert units
-    def convert_units(self, ddf):
-        """Convert DOXY from μmol/L to μmol/kg using seawater density."""
-        
-        if 'DOXY' not in ddf.columns:
-            return ddf
-        
-        if not self.add_derived_vars:
-            raise ValueError(
-                    "DOXY unit conversion requires derived variables "
-                    "Set add_derived_vars=True to enable unit conversion."
-                )
-        
-        # Ensure required derived columns exist (should be added if add_derived_vars=True)
-        required_cols = ['ABS_SAL_COMPUTED', 'CONSERVATIVE_TEMP_COMPUTED']
-        missing = [col for col in required_cols if col not in ddf.columns]
-        if missing:
-            raise RuntimeError(f"Missing required columns for DOXY conversion: {missing_cols}.")
-        
-        def convert_doxy_partition(df):
-            # convert DOXY units in a single partition.
-            sigma0 = gsw.density.sigma0(df['ABS_SAL_COMPUTED'], df['CONSERVATIVE_TEMP_COMPUTED'])
-            correction_factor = sigma0 / 1000 + 1
-            df['DOXY'] = df['DOXY'] / correction_factor
-            return df
-        
-        print("Converting DOXY from μmol/L to μmol/kg")
-        ddf = ddf.map_partitions(
-            convert_doxy_partition, 
-            meta=ddf._meta
-        )
-        
-        return ddf
-
-#------------------------------------------------------------------------------#
 ## Convert file
     def convert(self, filenames=None, filepath=None):
         """Override convert to handle single file to compute delayed operations, 
@@ -336,6 +307,7 @@ class ConverterSaildrones(Converter):
             if self.add_derived_vars:
                 print("Adding derived variables")
                 ddf = self.compute_derived_variables(ddf)
+            ddf = self.convert_units(ddf)
             ddf = self.reorder_columns(ddf)
             ddf = ddf.drop_duplicates()
             self.to_parquet(ddf)

--- a/crocolaketools/converter/unit_converter.py
+++ b/crocolaketools/converter/unit_converter.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+## @file unit_converter.py
+#
+#  Shared unit conversion functions and registry
+#
+## ## @author David Nady <davidnady4yad@gmail.com>
+#
+## @date Sat 05 Sep 2025
+
+##########################################################################
+import gsw
+import warnings
+##########################################################################
+
+#------------------------------------------------------------------------------#
+# Conversions
+#------------------------------------------------------------------------------#
+
+def micromol_L_to_micromol_kg(ddf, col):
+    """Convert concentration from μmol/L to μmol/kg using seawater density.
+    Requires columns 'ABS_SAL_COMPUTED' and 'CONSERVATIVE_TEMP_COMPUTED'.
+    """
+
+    # Ensure required derived columns exist (should be added if add_derived_vars=True)
+    required_cols = ['ABS_SAL_COMPUTED', 'CONSERVATIVE_TEMP_COMPUTED']
+    missing = [col for col in required_cols if col not in ddf.columns]
+    if missing:
+        raise ValueError(f"Missing required columns for {col} conversion: {missing}"
+                          "Set add_derived_vars=True to enable unit conversion.")
+
+    def convert_partition(df):
+        # convert DOXY units in a single partition.
+        sigma0 = gsw.density.sigma0(df['ABS_SAL_COMPUTED'], df['CONSERVATIVE_TEMP_COMPUTED'])
+        correction_factor = sigma0 / 1000 + 1
+        df['DOXY'] = df['DOXY'] / correction_factor
+        return df
+
+    print("Converting DOXY from μmol/L to μmol/kg")
+    ddf = ddf.map_partitions(
+        convert_partition, 
+        meta=ddf._meta
+    )
+
+    return ddf
+    
+#------------------------------------------------------------------------------#
+
+# ... Add new conversions here ...
+
+#------------------------------------------------------------------------------#
+
+#------------------------------------------------------------------------------#
+# Conversion mapping dictionary
+conversion_map = {
+    "micromol/L2micromol/kg": micromol_L_to_micromol_kg,
+}
+
+

--- a/crocolaketools/converter/units_conversion.py
+++ b/crocolaketools/converter/units_conversion.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-## @file unit_converter.py
+## @file units_conversion.py
 #
 #  Shared unit conversion functions and registry
 #
 ## ## @author David Nady <davidnady4yad@gmail.com>
 #
-## @date Sat 05 Sep 2025
+## @date Fri 05 Sep 2025
 
 ##########################################################################
 import gsw
@@ -43,17 +43,12 @@ def micromol_L_to_micromol_kg(ddf, col):
     )
 
     return ddf
-    
-#------------------------------------------------------------------------------#
 
+#------------------------------------------------------------------------------#
 # ... Add new conversions here ...
-
-#------------------------------------------------------------------------------#
 
 #------------------------------------------------------------------------------#
 # Conversion mapping dictionary
 conversion_map = {
     "micromol/L2micromol/kg": micromol_L_to_micromol_kg,
 }
-
-


### PR DESCRIPTION
## Description

This PR implements the conversion of Saildrones oxygen (DOXY) data from micromoles/L to micromoles/kg.

### Fixes

closes #35.

### Type of change

- Added `convert_units` method to `converter.py` .
- Added new module `units_conversion.py` with methods to convert units.
- Applied conversion using gsw’s sigma0 (density anomaly) to compute correction factor:
  c[µmol/kg] = c[µmol/L] / (sigma0/1e3 + 1).
- Declare conversion mappings in `converterSaildrones.py` like, `self.cols_to_convert = {"DOXY": "micromol/L2micromol/kg"}`

## How Has This Been Tested?

Verified locally on sample Saildrones datasets.
Additional unit tests under development in `test_data` to confirm values are correctly converted.

## Notes

The conversion will fail if `add_derived_variables=False`, since it depends on conservative temperature and absolute salinity. Setting it to `False` will lead to incorrect values.