### PR TITLE
[FEATURE] Add downloader submodule for spray gliders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.vscode

--- a/crocolaketools/config/config.yaml
+++ b/crocolaketools/config/config.yaml
@@ -92,7 +92,7 @@ GLODAP_BGC:
 SprayGliders_PHY:
   db: SprayGliders
   db_type: PHY
-  input_path: ../demo/demo_SPRAY_PHY/
+  input_path: ../demo/demo_SPRAY/
   outdir_pq: ../demo/parquet/demo_SPRAY_PHY/
   outdir_schema: ./schemas/
   fname_pq: demo_SPRAY_PHY
@@ -103,7 +103,7 @@ SprayGliders_PHY:
 SprayGliders_BGC:
   db: SprayGliders
   db_type: BGC
-  input_path: ../demo/demo_SPRAY_BGC/
+  input_path: ../demo/demo_SPRAY/
   outdir_pq: ../demo/parquet/demo_SPRAY_BGC/
   outdir_schema: ./schemas/
   fname_pq: demo_SPRAY_BGC

--- a/crocolaketools/downloader/downloaderSprayGliders.py
+++ b/crocolaketools/downloader/downloaderSprayGliders.py
@@ -173,7 +173,6 @@ class DownloaderSprayGliders(Downloader):
                 url,
                 timeout=5,
                 stream=True,
-                # headers={"User-Agent": "Mozilla/5.0"}, 
             )
             if response.ok:
                 response.close()

--- a/crocolaketools/downloader/downloaderSprayGliders.py
+++ b/crocolaketools/downloader/downloaderSprayGliders.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+## @file downloaderSprayGliders.py
+#
+# Downloader for Spray Gliders Level-3 NetCDF files.
+#
+## @author mahi-anol
+#
+## @date Sat 21 Mar 2026
+
+##########################################################################
+import os
+import requests
+
+from crocolaketools.downloader.downloader import Downloader
+##########################################################################
+
+# Base URL for Spray Gliders Level-3 files hosted on spraydata.ucsd.edu
+SPRAY_BASE_URL = "https://spraydata.ucsd.edu/erddap/files"
+
+# Mapping from local filename to ERDDAP folder/file path.
+# Each entry is (local_fname, remote_path) where remote_path is relative
+# to SPRAY_BASE_URL. The local filename matches the issue #40 specification.
+SPRAY_FILES = {
+    "Calypso.nc":       "binnedCalypso/Calypso.nc",
+    "CORC.nc":          "binnedCORC/CORC.nc",
+    "CUGN_along.nc":    "binnedCUGNalong/CUGN_along.nc",
+    "CUGN_line_56.nc":  "binnedCUGN56/CUGN_line_56.nc",
+    "CUGN_line_66.nc":  "binnedCUGN66/CUGN_line_66.nc",
+    "CUGN_line_80.nc":  "binnedCUGN80/CUGN_line_80.nc",
+    "CUGN_line_90.nc":  "binnedCUGN90/CUGN_line_90.nc",
+    "CUGN_line_93.nc":  "binnedCUGN93/CUGN_line_93.nc",
+    "FLEAT.nc":         "binnedFLEAT/FLEAT.nc",
+    "GoM.nc":           "binnedGoM/GoM.nc",
+    "GulfStream.nc":    "binnedGS/GulfStream.nc",
+    "Hawaii.nc":        "binnedHawaii/Hawaii.nc",
+    "NASCar.nc":        "binnedNASCar/NASCar.nc",
+    "NLIWI_IWISE.nc":   "binnedNLIWI_IWISE/NLIWI_IWISE.nc",
+    "OKMC.nc":          "binnedOKMC/OKMC.nc",
+    "PEACH.nc":         "binnedPEACH/PEACH.nc",
+    "ROGER.nc":         "binnedRoger/ROGER.nc",
+    "Solomon.nc":       "binnedSolomon/Solomon.nc",
+}
+##########################################################################
+
+
+class DownloaderSprayGliders(Downloader):
+    """class DownloaderSprayGliders: download Spray Gliders Level-3 NetCDF
+    files from spraydata.ucsd.edu and store them locally in their original,
+    unmodified form.
+
+    No schema mapping or data manipulation is performed here. The raw
+    NetCDF files are saved exactly as served by the remote host, ready
+    for subsequent conversion by ConverterSprayGliders.
+
+    The destination directory is resolved from the config dict /
+    config.yaml, mirroring the pattern used by ConverterSprayGliders and
+    DownloaderGLODAP.
+
+    Files are skipped if they already exist locally and overwrite=False.
+    get_url() is used to validate each file URL before downloading.
+
+    Typical usage
+    -------------
+    >>> config = {'db': 'SprayGliders', 'db_type': 'PHY'}
+    >>> d = DownloaderSprayGliders(config=config)
+    >>> d.spray_download()
+    """
+
+    # ------------------------------------------------------------------ #
+    # Constructors/Destructors                                             #
+    # ------------------------------------------------------------------ #
+
+    def __init__(
+        self,
+        config: dict = None,
+        fnames: list = None,
+        base_url: str = SPRAY_BASE_URL,
+        overwrite: bool = False,
+    ):
+        """Constructor.
+
+        Arguments
+        ---------
+        config   : configuration dictionary. Must contain at least
+                   'db' (='SprayGliders') and 'db_type' ('PHY' or 'BGC').
+                   Any key not supplied is read from config.yaml.
+                   The resolved 'input_path' is used as the download
+                   destination (set by the base Downloader).
+        fnames   : dict mapping local filename to remote ERDDAP path.
+                   Defaults to SPRAY_FILES.
+        base_url : base URL for the Spray Gliders Level-3 files.
+        overwrite: if False (default) and a file already exists on disk,
+                   the download is skipped.
+        """
+        if config is None:
+            config = {
+                'db': 'SprayGliders',
+                'db_type': 'PHY',
+            }
+
+        # base class resolves input_path from config + config.yaml and
+        # creates the directory if needed
+        super().__init__(config)
+
+        self.fnames = fnames if fnames is not None else SPRAY_FILES
+        self.base_url = base_url
+        self.overwrite = overwrite
+
+    # ------------------------------------------------------------------ #
+    # Public interface                                                     #
+    # ------------------------------------------------------------------ #
+
+    def spray_download(self) -> list:
+        """Download all Spray Gliders Level-3 files to self.input_path.
+
+        For each filename in self.fnames, checks if the file already
+        exists locally (skip if overwrite=False), validates the remote
+        URL via get_url(), then downloads using the inherited
+        _download_file() method.
+
+        Returns
+        -------
+        list
+            Absolute paths to all downloaded (or pre-existing) files.
+
+        Raises
+        ------
+        RuntimeError
+            If a file URL is not reachable.
+        """
+        downloaded = []
+
+        for fname, remote_path in self.fnames.items():
+            local_path = os.path.join(self.input_path, fname)
+
+            if self._is_already_downloaded(local_path):
+                print(
+                    f"{fname} already present at {local_path}. "
+                    "Use overwrite=True or use '--overwrite' flag to force re-download."
+                )
+                downloaded.append(local_path)
+                continue
+
+            url = self.get_url(fname)
+            print(f"Downloading {fname} from {url} ...")
+            self._download_file(url, local_path)
+            print(f"Saved to {local_path}")
+            downloaded.append(local_path)
+
+        return downloaded
+
+    def get_url(self, fname: str) -> str:
+        """Return the URL for fname if it is reachable.
+
+        Parameters
+        ----------
+        fname : filename to construct and validate the URL for.
+
+        Returns
+        -------
+        str
+            The full URL for the file.
+
+        Raises
+        ------
+        RuntimeError
+            If the URL is not reachable.
+        """
+        url = f"{self.base_url}/{self.fnames[fname]}"
+        try:
+            response = requests.get(
+                url,
+                timeout=5,
+                stream=True,
+                # headers={"User-Agent": "Mozilla/5.0"},
+            )
+            if response.ok:
+                response.close()
+                return url
+        except requests.RequestException:
+            pass
+        raise RuntimeError(f"URL not reachable: {url}")
+
+##########################################################################
+
+if __name__ == "__main__":
+    DownloaderSprayGliders()

--- a/crocolaketools/downloader/downloaderSprayGliders.py
+++ b/crocolaketools/downloader/downloaderSprayGliders.py
@@ -142,8 +142,9 @@ class DownloaderSprayGliders(Downloader):
                 downloaded.append(local_path)
                 continue
 
+            url = f"{self.base_url}/{remote_path}"
             try:
-                url = self.get_url(fname)
+                self._check_url_reachable(url)
             except RuntimeError as e:
                 import warnings
                 warnings.warn(
@@ -184,6 +185,25 @@ class DownloaderSprayGliders(Downloader):
             If the URL is not reachable.
         """
         url = f"{self.base_url}/{self.fnames[fname]}"
+        self._check_url_reachable(url)
+        return url
+
+    def _check_url_reachable(self, url: str) -> None:
+        """Verify that a URL is reachable.
+
+        Uses a streaming GET (not HEAD, because the ERDDAP server does
+        not always respond to HEAD requests) and closes the connection
+        immediately after checking the status code.
+
+        Parameters
+        ----------
+        url : full URL to check.
+
+        Raises
+        ------
+        RuntimeError
+            If the URL is not reachable.
+        """
         try:
             response = requests.get(
                 url,
@@ -193,7 +213,7 @@ class DownloaderSprayGliders(Downloader):
             )
             if response.ok:
                 response.close()
-                return url
+                return
         except requests.RequestException:
             pass
         raise RuntimeError(f"URL not reachable: {url}")

--- a/crocolaketools/downloader/downloaderSprayGliders.py
+++ b/crocolaketools/downloader/downloaderSprayGliders.py
@@ -173,7 +173,7 @@ class DownloaderSprayGliders(Downloader):
                 url,
                 timeout=5,
                 stream=True,
-                # headers={"User-Agent": "Mozilla/5.0"},
+                # headers={"User-Agent": "Mozilla/5.0"}, 
             )
             if response.ok:
                 response.close()

--- a/crocolaketools/downloader/downloaderSprayGliders.py
+++ b/crocolaketools/downloader/downloaderSprayGliders.py
@@ -119,17 +119,17 @@ class DownloaderSprayGliders(Downloader):
         URL via get_url(), then downloads using the inherited
         _download_file() method.
 
+        Files whose URLs are unreachable are skipped with a warning
+        rather than raising an error, so a single broken URL does not
+        abort the entire download.
+
         Returns
         -------
         list
-            Absolute paths to all downloaded (or pre-existing) files.
-
-        Raises
-        ------
-        RuntimeError
-            If a file URL is not reachable.
+            Absolute paths to all successfully downloaded (or pre-existing) files.
         """
         downloaded = []
+        skipped = []
 
         for fname, remote_path in self.fnames.items():
             local_path = os.path.join(self.input_path, fname)
@@ -142,11 +142,27 @@ class DownloaderSprayGliders(Downloader):
                 downloaded.append(local_path)
                 continue
 
-            url = self.get_url(fname)
+            try:
+                url = self.get_url(fname)
+            except RuntimeError as e:
+                import warnings
+                warnings.warn(
+                    f"Skipping {fname}: {e}. "
+                    "The file may have been removed/renamed on the server or the server may be temporarily down."
+                )
+                skipped.append(fname)
+                continue
+
             print(f"Downloading {fname} from {url} ...")
             self._download_file(url, local_path)
             print(f"Saved to {local_path}")
             downloaded.append(local_path)
+
+        if skipped:
+            print(
+                f"\nWarning: {len(skipped)} file(s) were skipped due to unreachable URLs: "
+                f"{', '.join(skipped)}"
+            )
 
         return downloaded
 
@@ -173,6 +189,7 @@ class DownloaderSprayGliders(Downloader):
                 url,
                 timeout=5,
                 stream=True,
+                headers={"User-Agent": "Mozilla/5.0"},
             )
             if response.ok:
                 response.close()

--- a/crocolaketools/test/test_downloaderSprayGliders.py
+++ b/crocolaketools/test/test_downloaderSprayGliders.py
@@ -189,7 +189,7 @@ class TestSprayDownload:
         d.input_path = str(tmp_path) + "/"
  
         with patch.object(
-            DownloaderSprayGliders, "get_url",
+            DownloaderSprayGliders, "_check_url_reachable",
             side_effect=RuntimeError("URL not reachable: ...")
         ):
             with warnings.catch_warnings(record=True) as caught:

--- a/crocolaketools/test/test_downloaderSprayGliders.py
+++ b/crocolaketools/test/test_downloaderSprayGliders.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+
+## @file test_downloaderSprayGliders.py
+#
+#
+## @author mahi-anol
+#
+## @date Sat 21 Mar 2026
+
+##########################################################################
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from crocolaketools.downloader.downloaderSprayGliders import (
+    SPRAY_BASE_URL,
+    SPRAY_FILES,
+    DownloaderSprayGliders,
+)
+##########################################################################
+
+DUMMY_CONFIG = {'db': 'SprayGliders', 'db_type': 'PHY'}
+
+
+class TestDownloaderSprayGlidersInit:
+    """Tests for DownloaderSprayGliders.__init__"""
+
+    def test_defaults(self, mock_base_downloader):
+        """Constructor stores correct defaults when no args given."""
+        d = DownloaderSprayGliders()
+        assert d.fnames == SPRAY_FILES
+        assert d.base_url == SPRAY_BASE_URL
+        assert d.overwrite is False
+
+    def test_custom_args(self, mock_base_downloader):
+        """Constructor stores custom arguments."""
+        custom_files = {"CORC.nc": "binnedCORC/CORC.nc", "GulfStream.nc": "binnedGS/GulfStream.nc"}
+        custom_url = "https://example.com/spray"
+
+        d = DownloaderSprayGliders(
+            config=DUMMY_CONFIG,
+            fnames=custom_files,
+            base_url=custom_url,
+            overwrite=True,
+        )
+        assert d.fnames == custom_files
+        assert d.base_url == custom_url
+        assert d.overwrite is True
+
+    def test_inherits_downloader(self):
+        """DownloaderSprayGliders is a subclass of Downloader."""
+        from crocolaketools.downloader.downloader import Downloader
+        assert issubclass(DownloaderSprayGliders, Downloader)
+
+    def test_default_config_is_spraygliders_phy(self, mock_base_downloader):
+        """When no config is given, base class is called with SprayGliders/PHY."""
+        with patch(
+            "crocolaketools.downloader.downloaderSprayGliders.Downloader.__init__"
+        ) as mock_super:
+            mock_super.return_value = None
+            DownloaderSprayGliders()
+            called_config = mock_super.call_args[0][0]
+            assert called_config['db'] == 'SprayGliders'
+            assert called_config['db_type'] == 'PHY'
+
+
+class TestGetUrl:
+    """Tests for DownloaderSprayGliders.get_url."""
+
+    def test_returns_url_when_reachable(self, mock_base_downloader):
+        """Returns full URL when the file is reachable."""
+        d = DownloaderSprayGliders()
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+
+        with patch(
+            "crocolaketools.downloader.downloaderSprayGliders.requests.get",
+            return_value=mock_resp,
+        ):
+            url = d.get_url("CORC.nc")
+        assert url == f"{SPRAY_BASE_URL}/{SPRAY_FILES['CORC.nc']}"
+
+    def test_raises_when_url_unreachable(self, mock_base_downloader):
+        """RuntimeError raised when the URL is not reachable."""
+        d = DownloaderSprayGliders()
+
+        with patch(
+            "crocolaketools.downloader.downloaderSprayGliders.requests.get",
+            side_effect=requests.RequestException("down"),
+        ):
+            with pytest.raises(RuntimeError, match="URL not reachable"):
+                d.get_url("CORC.nc")
+
+
+class TestIsAlreadyDownloaded:
+    """Tests for Downloader._is_already_downloaded (inherited)."""
+
+    def test_file_exists_no_overwrite(self, tmp_path, mock_base_downloader):
+        """Returns True when file exists and overwrite=False."""
+        existing = tmp_path / "CORC.nc"
+        existing.write_bytes(b"data")
+        d = DownloaderSprayGliders(overwrite=False)
+        assert d._is_already_downloaded(str(existing)) is True
+
+    def test_file_exists_with_overwrite(self, tmp_path, mock_base_downloader):
+        """Returns False when file exists but overwrite=True."""
+        existing = tmp_path / "CORC.nc"
+        existing.write_bytes(b"data")
+        d = DownloaderSprayGliders(overwrite=True)
+        assert d._is_already_downloaded(str(existing)) is False
+
+    def test_file_missing(self, tmp_path, mock_base_downloader):
+        """Returns False when file does not exist."""
+        d = DownloaderSprayGliders(overwrite=False)
+        assert d._is_already_downloaded(str(tmp_path / "missing.nc")) is False
+
+
+class TestSprayDownload:
+    """Tests for DownloaderSprayGliders.spray_download."""
+
+    def test_skips_existing_files(self, tmp_path, capsys, mock_base_downloader):
+        """No HTTP request made when files exist and overwrite=False."""
+        d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"}, overwrite=False)
+        d.input_path = str(tmp_path) + "/"
+        existing = os.path.join(d.input_path, "CORC.nc")
+        with open(existing, "wb") as fh:
+            fh.write(b"data")
+
+        with patch.object(DownloaderSprayGliders, "_download_file") as mock_dl:
+            result = d.spray_download()
+            mock_dl.assert_not_called()
+
+        assert result == [existing]
+        captured = capsys.readouterr()
+        assert "already present" in captured.out
+
+    def test_downloads_missing_file(self, tmp_path, mock_base_downloader):
+        """File is downloaded when not already present."""
+        d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"})
+        d.input_path = str(tmp_path) + "/"
+        expected_path = os.path.join(d.input_path, "CORC.nc")
+        expected_url = f"{SPRAY_BASE_URL}/binnedCORC/CORC.nc"
+
+        with patch.object(
+            DownloaderSprayGliders, "get_url",
+            return_value=expected_url
+        ), patch.object(DownloaderSprayGliders, "_download_file") as mock_dl:
+            result = d.spray_download()
+            mock_dl.assert_called_once_with(expected_url, expected_path)
+
+        assert result == [expected_path]
+
+    def test_returns_correct_paths(self, tmp_path, mock_base_downloader):
+        """spray_download returns local_path for each file correctly."""
+        fnames = {"CORC.nc": "binnedCORC/CORC.nc", "GulfStream.nc": "binnedGS/GulfStream.nc"}
+        d = DownloaderSprayGliders(fnames=fnames)
+        d.input_path = str(tmp_path) + "/"
+        expected_paths = [os.path.join(d.input_path, f) for f in fnames]
+
+        with patch.object(
+            DownloaderSprayGliders, "get_url",
+            side_effect=lambda f: f"{SPRAY_BASE_URL}/{fnames[f]}"
+        ), patch.object(DownloaderSprayGliders, "_download_file"):
+            result = d.spray_download()
+
+        assert result == expected_paths
+
+    def test_overwrite_triggers_redownload(self, tmp_path, mock_base_downloader):
+        """Existing file is re-downloaded when overwrite=True."""
+        d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"}, overwrite=True)
+        d.input_path = str(tmp_path) + "/"
+        existing = os.path.join(d.input_path, "CORC.nc")
+        with open(existing, "wb") as fh:
+            fh.write(b"old data")
+
+        with patch.object(
+            DownloaderSprayGliders, "get_url",
+            return_value=f"{SPRAY_BASE_URL}/binnedCORC/CORC.nc"
+        ), patch.object(DownloaderSprayGliders, "_download_file") as mock_dl:
+            d.spray_download()
+            mock_dl.assert_called_once()
+
+    def test_raises_when_url_unreachable(self, tmp_path, mock_base_downloader):
+        """RuntimeError propagated when get_url raises for a file."""
+        d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"})
+        d.input_path = str(tmp_path) + "/"
+
+        with patch.object(
+            DownloaderSprayGliders, "get_url",
+            side_effect=RuntimeError("URL not reachable: ...")
+        ):
+            with pytest.raises(RuntimeError, match="URL not reachable"):
+                d.spray_download()
+
+
+##########################################################################
+# Fixtures
+##########################################################################
+
+@pytest.fixture
+def mock_base_downloader():
+    """Patch Downloader.__init__ so tests don't need config.yaml or
+    crocolakeloader.params to be installed."""
+    with patch(
+        "crocolaketools.downloader.downloaderSprayGliders.Downloader.__init__",
+        return_value=None,
+    ):
+        yield
+
+
+##########################################################################
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/crocolaketools/test/test_downloaderSprayGliders.py
+++ b/crocolaketools/test/test_downloaderSprayGliders.py
@@ -10,35 +10,35 @@
 ##########################################################################
 import os
 from unittest.mock import MagicMock, patch
-
+ 
 import pytest
 import requests
-
+ 
 from crocolaketools.downloader.downloaderSprayGliders import (
     SPRAY_BASE_URL,
     SPRAY_FILES,
     DownloaderSprayGliders,
 )
 ##########################################################################
-
+ 
 DUMMY_CONFIG = {'db': 'SprayGliders', 'db_type': 'PHY'}
-
-
+ 
+ 
 class TestDownloaderSprayGlidersInit:
     """Tests for DownloaderSprayGliders.__init__"""
-
+ 
     def test_defaults(self, mock_base_downloader):
         """Constructor stores correct defaults when no args given."""
         d = DownloaderSprayGliders()
         assert d.fnames == SPRAY_FILES
         assert d.base_url == SPRAY_BASE_URL
         assert d.overwrite is False
-
+ 
     def test_custom_args(self, mock_base_downloader):
         """Constructor stores custom arguments."""
         custom_files = {"CORC.nc": "binnedCORC/CORC.nc", "GulfStream.nc": "binnedGS/GulfStream.nc"}
         custom_url = "https://example.com/spray"
-
+ 
         d = DownloaderSprayGliders(
             config=DUMMY_CONFIG,
             fnames=custom_files,
@@ -48,12 +48,12 @@ class TestDownloaderSprayGlidersInit:
         assert d.fnames == custom_files
         assert d.base_url == custom_url
         assert d.overwrite is True
-
+ 
     def test_inherits_downloader(self):
         """DownloaderSprayGliders is a subclass of Downloader."""
         from crocolaketools.downloader.downloader import Downloader
         assert issubclass(DownloaderSprayGliders, Downloader)
-
+ 
     def test_default_config_is_spraygliders_phy(self, mock_base_downloader):
         """When no config is given, base class is called with SprayGliders/PHY."""
         with patch(
@@ -64,62 +64,62 @@ class TestDownloaderSprayGlidersInit:
             called_config = mock_super.call_args[0][0]
             assert called_config['db'] == 'SprayGliders'
             assert called_config['db_type'] == 'PHY'
-
-
+ 
+ 
 class TestGetUrl:
     """Tests for DownloaderSprayGliders.get_url."""
-
+ 
     def test_returns_url_when_reachable(self, mock_base_downloader):
         """Returns full URL when the file is reachable."""
         d = DownloaderSprayGliders()
         mock_resp = MagicMock()
         mock_resp.ok = True
-
+ 
         with patch(
             "crocolaketools.downloader.downloaderSprayGliders.requests.get",
             return_value=mock_resp,
         ):
             url = d.get_url("CORC.nc")
         assert url == f"{SPRAY_BASE_URL}/{SPRAY_FILES['CORC.nc']}"
-
+ 
     def test_raises_when_url_unreachable(self, mock_base_downloader):
         """RuntimeError raised when the URL is not reachable."""
         d = DownloaderSprayGliders()
-
+ 
         with patch(
             "crocolaketools.downloader.downloaderSprayGliders.requests.get",
             side_effect=requests.RequestException("down"),
         ):
             with pytest.raises(RuntimeError, match="URL not reachable"):
                 d.get_url("CORC.nc")
-
-
+ 
+ 
 class TestIsAlreadyDownloaded:
     """Tests for Downloader._is_already_downloaded (inherited)."""
-
+ 
     def test_file_exists_no_overwrite(self, tmp_path, mock_base_downloader):
         """Returns True when file exists and overwrite=False."""
         existing = tmp_path / "CORC.nc"
         existing.write_bytes(b"data")
         d = DownloaderSprayGliders(overwrite=False)
         assert d._is_already_downloaded(str(existing)) is True
-
+ 
     def test_file_exists_with_overwrite(self, tmp_path, mock_base_downloader):
         """Returns False when file exists but overwrite=True."""
         existing = tmp_path / "CORC.nc"
         existing.write_bytes(b"data")
         d = DownloaderSprayGliders(overwrite=True)
         assert d._is_already_downloaded(str(existing)) is False
-
+ 
     def test_file_missing(self, tmp_path, mock_base_downloader):
         """Returns False when file does not exist."""
         d = DownloaderSprayGliders(overwrite=False)
         assert d._is_already_downloaded(str(tmp_path / "missing.nc")) is False
-
-
+ 
+ 
 class TestSprayDownload:
     """Tests for DownloaderSprayGliders.spray_download."""
-
+ 
     def test_skips_existing_files(self, tmp_path, capsys, mock_base_downloader):
         """No HTTP request made when files exist and overwrite=False."""
         d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"}, overwrite=False)
@@ -127,46 +127,46 @@ class TestSprayDownload:
         existing = os.path.join(d.input_path, "CORC.nc")
         with open(existing, "wb") as fh:
             fh.write(b"data")
-
+ 
         with patch.object(DownloaderSprayGliders, "_download_file") as mock_dl:
             result = d.spray_download()
             mock_dl.assert_not_called()
-
+ 
         assert result == [existing]
         captured = capsys.readouterr()
         assert "already present" in captured.out
-
+ 
     def test_downloads_missing_file(self, tmp_path, mock_base_downloader):
         """File is downloaded when not already present."""
         d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"})
         d.input_path = str(tmp_path) + "/"
         expected_path = os.path.join(d.input_path, "CORC.nc")
         expected_url = f"{SPRAY_BASE_URL}/binnedCORC/CORC.nc"
-
+ 
         with patch.object(
             DownloaderSprayGliders, "get_url",
             return_value=expected_url
         ), patch.object(DownloaderSprayGliders, "_download_file") as mock_dl:
             result = d.spray_download()
             mock_dl.assert_called_once_with(expected_url, expected_path)
-
+ 
         assert result == [expected_path]
-
+ 
     def test_returns_correct_paths(self, tmp_path, mock_base_downloader):
         """spray_download returns local_path for each file correctly."""
         fnames = {"CORC.nc": "binnedCORC/CORC.nc", "GulfStream.nc": "binnedGS/GulfStream.nc"}
         d = DownloaderSprayGliders(fnames=fnames)
         d.input_path = str(tmp_path) + "/"
         expected_paths = [os.path.join(d.input_path, f) for f in fnames]
-
+ 
         with patch.object(
             DownloaderSprayGliders, "get_url",
             side_effect=lambda f: f"{SPRAY_BASE_URL}/{fnames[f]}"
         ), patch.object(DownloaderSprayGliders, "_download_file"):
             result = d.spray_download()
-
+ 
         assert result == expected_paths
-
+ 
     def test_overwrite_triggers_redownload(self, tmp_path, mock_base_downloader):
         """Existing file is re-downloaded when overwrite=True."""
         d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"}, overwrite=True)
@@ -174,31 +174,35 @@ class TestSprayDownload:
         existing = os.path.join(d.input_path, "CORC.nc")
         with open(existing, "wb") as fh:
             fh.write(b"old data")
-
+ 
         with patch.object(
             DownloaderSprayGliders, "get_url",
             return_value=f"{SPRAY_BASE_URL}/binnedCORC/CORC.nc"
         ), patch.object(DownloaderSprayGliders, "_download_file") as mock_dl:
             d.spray_download()
             mock_dl.assert_called_once()
-
-    def test_raises_when_url_unreachable(self, tmp_path, mock_base_downloader):
-        """RuntimeError propagated when get_url raises for a file."""
+ 
+    def test_skips_with_warning_when_url_unreachable(self, tmp_path, mock_base_downloader):
+        """Unreachable URL is skipped with a warning instead of raising."""
+        import warnings
         d = DownloaderSprayGliders(fnames={"CORC.nc": "binnedCORC/CORC.nc"})
         d.input_path = str(tmp_path) + "/"
-
+ 
         with patch.object(
             DownloaderSprayGliders, "get_url",
             side_effect=RuntimeError("URL not reachable: ...")
         ):
-            with pytest.raises(RuntimeError, match="URL not reachable"):
-                d.spray_download()
-
-
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                result = d.spray_download()
+                assert any("Skipping CORC.nc" in str(w.message) for w in caught)
+            assert result == []
+ 
+ 
 ##########################################################################
 # Fixtures
 ##########################################################################
-
+ 
 @pytest.fixture
 def mock_base_downloader():
     """Patch Downloader.__init__ so tests don't need config.yaml or
@@ -208,9 +212,9 @@ def mock_base_downloader():
         return_value=None,
     ):
         yield
-
-
+ 
+ 
 ##########################################################################
-
+ 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/scripts/download_spraygliders.py
+++ b/scripts/download_spraygliders.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+## @file download_spraygliders.py
+#
+# CLI for downloading Spray Gliders Level-3 NetCDF files.
+#
+## @author mahi-anol
+#
+## @date Sat 21 Mar 2026
+
+##########################################################################
+import argparse
+from datetime import datetime
+
+from crocolaketools.downloader.downloaderSprayGliders import (
+    SPRAY_BASE_URL,
+    SPRAY_FILES,
+    DownloaderSprayGliders,
+)
+##########################################################################
+
+
+def download_spraygliders(
+    config: dict = None,
+    fnames: list = None,
+    base_url: str = SPRAY_BASE_URL,
+    overwrite: bool = False,
+) -> list:
+    """Download Spray Gliders Level-3 NetCDF files.
+
+    Parameters
+    ----------
+    config   : configuration dict passed to DownloaderSprayGliders.
+               Must contain at least 'db' and 'db_type'.
+               Defaults to {'db': 'SprayGliders', 'db_type': 'PHY'}.
+    fnames   : list of filenames to download. Defaults to SPRAY_FILES.
+    base_url : base URL for the Level-3 files.
+    overwrite: re-download even if file already exists.
+
+    Returns
+    -------
+    list
+        Paths to all downloaded files.
+    """
+    downloader = DownloaderSprayGliders(
+        config=config,
+        fnames=fnames,
+        base_url=base_url,
+        overwrite=overwrite,
+    )
+    return downloader.spray_download()
+
+
+#------------------------------------------------------------------------------#
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download Spray Gliders Level-3 NetCDF files to a local directory."
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        default=False,
+        help="Re-download even if files already exist on disk",
+    )
+    parser.add_argument(
+        "--config",
+        action="store_true",
+        default=False,
+        help="Use config.yaml defaults for input_path",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        default=None,
+        help=(
+            "Subset of filenames to download (e.g. --files CORC.nc GulfStream.nc). "
+            "Must match keys in SPRAY_FILES. Defaults to all files."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    config = None if args.config else {'db': 'SprayGliders', 'db_type': 'PHY'}
+
+    # if --files provided, build a subset dict from SPRAY_FILES
+    fnames = None
+    if args.files:
+        fnames = {f: SPRAY_FILES[f] for f in args.files if f in SPRAY_FILES}
+        missing = [f for f in args.files if f not in SPRAY_FILES]
+        if missing:
+            print(f"Warning: unknown filenames ignored: {missing}")
+
+    download_spraygliders(
+        config=config,
+        fnames=fnames,
+        overwrite=args.overwrite,
+    )
+
+
+##########################################################################
+
+if __name__ == "__main__":
+    print(datetime.now())
+    print()
+    main()
+    print("download_spraygliders.py executed successfully")
+    print()
+    print(datetime.now())

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             'download_demo_data = scripts.download_demo_data:main',
             'download_glodap = scripts.download_glodap:main',
             'download_oleanderXBT = scripts.download_oleanderXBT:main',
+            'download_spraygliders = scripts.download_spraygliders:main',
             'glodap2parquet = scripts.glodap2parquet:main',
             'merge_crocolake = scripts.merge_crocolake:main',
             'oleanderXBT2parquet = scripts.oleanderXBT2parquet:main',


### PR DESCRIPTION
## Description

This PR implements a Spray Gliders data downloader submodule for CrocoLakeTools, as requested in issue #40. It adds a `DownloaderSprayGliders` class that downloads the full list of Spray Gliders Level-3 NetCDF files from `spraydata.ucsd.edu/erddap/files`, and saves them to the path specified in `config.yaml` (default: `crocolaketools/demo/demo_SPRAY`), making them immediately usable by the existing `ConverterSprayGliders` pipeline.

Each file is hosted in its own ERDDAP folder on the server (e.g. `binnedCORC/CORC.nc`). The downloader maps local filenames to their remote ERDDAP paths via a `SPRAY_FILES` dict, validates each URL before downloading, and skips files that are already present locally unless `overwrite=True` or enforced by `--overwrite` flag.

### Fixes

Resolves issue #40.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (specify)

## How Has This Been Tested?

**Unit tests** (`crocolaketools/test/test_downloaderSprayGliders.py`):
- Run with: `pytest crocolaketools/test/test_downloaderSprayGliders.py -v`
- All 14 tests pass locally. Tests cover:
  - Default and custom constructor arguments
  - Correct inheritance from `Downloader`
  - `get_url()` happy path and unreachable URL
  - `_is_already_downloaded()` logic (file absent, file present, overwrite)
  - Skip-if-present behaviour (`overwrite=False`)
  - Download of missing file with correct URL and local path
  - Return value of `spray_download()` for each file
  - Forced re-download with `overwrite=True`
  - `RuntimeError` propagation when URL is unreachable

**Integration test** (steps):
```bash
# Download all Spray Gliders Level-3 files
python scripts/download_spraygliders.py

# Verify skip-if-present
python scripts/download_spraygliders.py  # should print "already present" for each file

# Verify overwrite
python scripts/download_spraygliders.py --overwrite

# Verify subset download
python scripts/download_spraygliders.py --files CORC.nc GulfStream.nc --overwrite

# Convert to parquet and verify output
python scripts/spray2parquet.py --config
ls crocolaketools/demo/parquet/demo_SPRAY_PHY/
ls crocolaketools/demo/parquet/demo_SPRAY_BGC/
```

The full converter pipeline (`spray2parquet.py --config`) completed successfully end-to-end, producing parquet output for both PHY and BGC variant,

## Checklist:

- [x] My code follows the [[contributing guidelines](https://github.com/enrico-mi/crocolaketools-public/blob/develop/CONTRIBUTE.md)](https://github.com/enrico-mi/crocolaketools-public/blob/develop/CONTRIBUTE.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned someone from the CrocoLake team to review this PR

## Comments

**BGC variant:** Both `SprayGliders_PHY` and `SprayGliders_BGC` now share the same `input_path: ../demo/demo_SPRAY/` in `config.yaml`, matching the pattern used by `GLODAP`. A single download run populates both pipelines. The full converter pipeline (`spray2parquet.py --config`) completes successfully for both PHY and BGC.

**URL validation:** During local testing I found out that some links from spraydata.ucsd.edu server does not respond to `HEAD` requests, so `_check_url_reachable()` uses `requests.get` with `stream=True` and closes the connection immediately after checking the status code. This avoids downloading the full file body just for validation.

**ERDDAP folder structure:** Each file is hosted in its own named folder on the ERDDAP server (e.g. `binnedCORC/CORC.nc`, `binnedGS/GulfStream.nc`). The `SPRAY_FILES` dict maps local filenames to their remote paths, keeping the URL construction explicit and easy to update if the server structure changes.
