### PR TITLE
fix(GLODAP): keep_best_values incorrectly removes valid QC values in GLODAP

### DIFF
--- a/crocolaketools/converter/converterGLODAP.py
+++ b/crocolaketools/converter/converterGLODAP.py
@@ -296,7 +296,7 @@ class ConverterGLODAP(Converter):
 
         # GLODAP's quality control columns end with "f" (e.g. "nitratef")
         # and good values are 0 or 2
-        condition = df[param].isin([0,2])
+        condition = ~df[param].isin([0, 2])
 
         # Find bad QC values
         df.loc[condition, param] = pd.NA


### PR DESCRIPTION
## Description

This PR fixes an issue in the GLODAP converter where the `keep_best_values` method incorrectly removes valid QC measurements.

The previous implementation was setting values with QC flags 0 and 2 (which represent good data) to `NA`. This PR corrects the logic so that only invalid QC values are removed, preserving high-quality observations.

### Fixes

Fixes #46.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (specify)

## How Has This Been Tested?

**Manual Testing**
- QC values equal to 0 and 2 are preserved
- QC values outside [0, 2] are set to `NA`

## Checklist:

- [x] My code follows the [contributing guidelines](https://github.com/enrico-mi/crocolaketools-public/blob/develop/CONTRIBUTE.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned someone from the CrocoLake team to review this PR

@enrico-mi