### PR TITLE
[Refactor] refactor oleanderxbt downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.vscode

--- a/crocolaketools/downloader/downloader.py
+++ b/crocolaketools/downloader/downloader.py
@@ -51,6 +51,9 @@ class Downloader:
         db            -- database name (e.g., 'OleanderXBT')
         db_type       -- 'PHY' or 'BGC'
         input_path    -- destination path where original files are stored
+        overwrite     -- if True, re-download files already present (default: False)
+        dryrun        -- if True, print summary without downloading (default: False)
+        num_threads   -- number of parallel download threads (default: 4)
         """
  
         if config is None:
@@ -106,6 +109,12 @@ class Downloader:
         os.makedirs(input_path, exist_ok=True)
         self.input_path = input_path
         print("Original files will be stored at " + self.input_path)
+ 
+        # Common download options -- subclasses may override these after
+        # calling super().__init__() if they accept them as constructor args.
+        self.overwrite = config.get("overwrite", False)
+        self.dryrun = config.get("dryrun", False)
+        self.num_threads = config.get("num_threads", 4)
  
     # ------------------------------------------------------------------ #
     # Methods                                                            #
@@ -273,7 +282,7 @@ class Downloader:
             "Download completed. Success: %d, Failed: %d", completed, failed
         )
         return completed, failed
-    
+ 
     @staticmethod
     def _format_size(size_bytes: int) -> str:
         """Return a human-readable string for a size in bytes.

--- a/crocolaketools/downloader/downloader.py
+++ b/crocolaketools/downloader/downloader.py
@@ -6,26 +6,25 @@
 #
 ## @author Enrico Milanese <enrico.milanese@whoi.edu>
 #         Updated by David Nady <davidnady4yad@gmail.com>
-#         Updated by Mahi Sarwar Anol <anol.mahi@gmail.com>
+#         Updated by mahi-anol
 #
 ## @date Tue 11 Feb 2025
 
 ##########################################################################
 import importlib.resources
+import logging
 import os
 import shutil
 import warnings
 import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urlparse
 
 import requests
 import yaml
 from tqdm import tqdm
 
 from crocolakeloader import params
-
-
-import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
 ##########################################################################
 
 
@@ -175,7 +174,7 @@ class Downloader:
             shutil.rmtree(macosx_path)
 
         os.remove(zip_path)
-    
+
     def download_parallel(
         self,
         url_path_pairs: list,
@@ -183,17 +182,17 @@ class Downloader:
         dryrun: bool = False,
     ) -> tuple:
         """Download multiple (url, local_path) pairs concurrently.
- 
+
         Uses ThreadPoolExecutor to call _download_file() for each pair.
         Logs progress and returns counts of completed and failed downloads.
- 
+
         Parameters
         ----------
         url_path_pairs : list of (url, local_path) tuples to download.
         num_threads    : number of concurrent download threads.
         dryrun         : if True, log what would be downloaded without
                          fetching anything.
- 
+
         Returns
         -------
         tuple
@@ -204,21 +203,21 @@ class Downloader:
             len(url_path_pairs),
             num_threads,
         )
- 
+
         if dryrun:
             for url, local_path in url_path_pairs:
                 logging.info("DRY RUN: Would download %s to %s", url, local_path)
             return len(url_path_pairs), 0
- 
+
         completed = 0
         failed = 0
- 
+
         with ThreadPoolExecutor(max_workers=num_threads) as executor:
             future_to_url = {
                 executor.submit(self._download_file, url, local_path): url
                 for url, local_path in url_path_pairs
             }
- 
+
             for future in as_completed(future_to_url):
                 url = future_to_url[future]
                 try:
@@ -228,11 +227,12 @@ class Downloader:
                 except Exception as exc:
                     failed += 1
                     logging.error("Failed to download %s: %s", url, exc)
- 
+
         logging.info(
             "Download completed. Success: %d, Failed: %d", completed, failed
         )
         return completed, failed
+
 ##########################################################################
 if __name__ == "__main__":
     Downloader()

--- a/crocolaketools/downloader/downloader.py
+++ b/crocolaketools/downloader/downloader.py
@@ -199,12 +199,16 @@ class Downloader:
         Uses ThreadPoolExecutor to call _download_file() for each pair.
         Logs progress and returns counts of completed and failed downloads.
  
+        In dryrun mode, sends a HEAD request to each URL to retrieve the
+        expected file size and prints a summary of what would be downloaded
+        and how much disk space it would require.
+ 
         Parameters
         ----------
         url_path_pairs : list of (url, local_path) tuples to download.
         num_threads    : number of concurrent download threads.
-        dryrun         : if True, log what would be downloaded without
-                         fetching anything.
+        dryrun         : if True, print a download summary without
+                         fetching any files.
  
         Returns
         -------
@@ -219,8 +223,31 @@ class Downloader:
         )
  
         if dryrun:
+            total_bytes = 0
+            rows = []
             for url, local_path in url_path_pairs:
-                logging.info("DRY RUN: Would download %s to %s", url, local_path)
+                already = os.path.isfile(local_path)
+                size_bytes = 0
+                size_str = "unknown"
+                try:
+                    head = requests.head(url, timeout=10, allow_redirects=True)
+                    if "content-length" in head.headers:
+                        size_bytes = int(head.headers["content-length"])
+                        size_str = self._format_size(size_bytes)
+                except requests.RequestException:
+                    pass
+ 
+                status = "already exists, would skip" if already else "would download"
+                if not already:
+                    total_bytes += size_bytes
+                rows.append((os.path.basename(local_path), size_str, status))
+ 
+            print("\nDry run summary:")
+            for fname, size, status in rows:
+                print(f"  {fname:<40} {size:>10}   ({status})")
+            print(f"\nTotal to download: {self._format_size(total_bytes)} "
+                  f"across {sum(1 for _, _, s in rows if 'would download' in s)} file(s).")
+            print()
             return len(url_path_pairs), 0
  
         completed = 0
@@ -246,6 +273,27 @@ class Downloader:
             "Download completed. Success: %d, Failed: %d", completed, failed
         )
         return completed, failed
+    
+    @staticmethod
+    def _format_size(size_bytes: int) -> str:
+        """Return a human-readable string for a size in bytes.
+ 
+        Parameters
+        ----------
+        size_bytes : size in bytes.
+ 
+        Returns
+        -------
+        str
+            Human-readable size string (e.g. '1.29 MB', '623 KB').
+        """
+        if size_bytes == 0:
+            return "unknown"
+        for unit in ["B", "KB", "MB", "GB"]:
+            if size_bytes < 1024:
+                return f"{size_bytes:.2f} {unit}"
+            size_bytes /= 1024
+        return f"{size_bytes:.2f} TB"
  
 ##########################################################################
 if __name__ == "__main__":

--- a/crocolaketools/downloader/downloader.py
+++ b/crocolaketools/downloader/downloader.py
@@ -6,7 +6,7 @@
 #
 ## @author Enrico Milanese <enrico.milanese@whoi.edu>
 #         Updated by David Nady <davidnady4yad@gmail.com>
-#         Updated by mahi-anol
+#         Updated by Mahi Sarwar Anol <anol.mahi@gmail.com>
 #
 ## @date Tue 11 Feb 2025
 
@@ -198,10 +198,11 @@ class Downloader:
         tuple
             (completed, failed) counts.
         """
+        actual_threads = min(num_threads, len(url_path_pairs))
         logging.info(
-            "Starting parallel download of %d files with %d threads",
+            "Starting download of %d files with %d threads",
             len(url_path_pairs),
-            num_threads,
+            actual_threads,
         )
 
         if dryrun:
@@ -212,7 +213,7 @@ class Downloader:
         completed = 0
         failed = 0
 
-        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        with ThreadPoolExecutor(max_workers=actual_threads) as executor:
             future_to_url = {
                 executor.submit(self._download_file, url, local_path): url
                 for url, local_path in url_path_pairs

--- a/crocolaketools/downloader/downloader.py
+++ b/crocolaketools/downloader/downloader.py
@@ -19,54 +19,54 @@ import warnings
 import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import urlparse
-
+ 
 import requests
 import yaml
 from tqdm import tqdm
-
+ 
 from crocolakeloader import params
 ##########################################################################
-
-
+ 
+ 
 class Downloader:
-
+ 
     """class Downloader: common facilities to configure downloads for different
     databases, mirroring the Converter's path handling.
     """
-
+ 
     # ------------------------------------------------------------------ #
     # Constructors/Destructors                                           #
     # ------------------------------------------------------------------ #
-
+ 
     def __init__(self, config=None):
         """Constructor
-
+ 
         Arguments:
-
+ 
         config -- configuration dictionary. Must contain at least 'db' and
                   'db_type'. If any value is not specified, defaults in
                   config.yaml are used; user-provided values override them.
-
+ 
         Relevant fields used by Downloader implementations:
         db            -- database name (e.g., 'OleanderXBT')
         db_type       -- 'PHY' or 'BGC'
         input_path    -- destination path where original files are stored
         """
-
+ 
         if config is None:
             raise ValueError("No config argument provided to Downloader.")
-
+ 
         db = config['db']
         db_type = config['db_type'].upper()
-
+ 
         config_path = importlib.resources.files("crocolaketools.config").joinpath("config.yaml")
         base_path = importlib.resources.files("crocolaketools.config")
         config_disk = yaml.safe_load(open(config_path))
         config_disk = config_disk[db + "_" + db_type]
-
+ 
         config_user_keys = list(config.keys())
         config_disk_keys = list(config_disk.keys())
-
+ 
         read_keys = [k for k in config_disk_keys if k not in config_user_keys]
         if len(read_keys)>0:
             for k in ["db","db_type"]:
@@ -74,10 +74,10 @@ class Downloader:
                     warnings.warn(f"User-specified and config file are not matching at key {k} (got {config[k]} and {config_disk[k]}), the user-specified value {config[k]} is used")
         for k in read_keys:
             config[k] = config_disk[k]
-
+ 
         print("Downloader configuration:")
         print(config)
-
+ 
         # Basic validation and assignments
         if isinstance(db,str):
             if db in params.databases:
@@ -89,7 +89,7 @@ class Downloader:
             raise ValueError("Database db not a string.")
         else:
             raise ValueError("No database provided.")
-
+ 
         if isinstance(db_type,str):
             if db_type in ["PHY","BGC"]:
                 self.db_type = db_type
@@ -98,7 +98,7 @@ class Downloader:
                 raise ValueError("Database db_type must be one of " + str(["PHY","BGC"]))
         elif db is not None:
             raise ValueError("Database type db_type not a string.")
-
+ 
         input_path = os.path.abspath(os.path.join(base_path, config["input_path"]))
         if input_path[-1] != "/":
             input_path = input_path + "/"
@@ -106,60 +106,73 @@ class Downloader:
         os.makedirs(input_path, exist_ok=True)
         self.input_path = input_path
         print("Original files will be stored at " + self.input_path)
-
+ 
     # ------------------------------------------------------------------ #
     # Methods                                                            #
     # ------------------------------------------------------------------ #
-
+ 
     def _is_already_downloaded(self, local_path: str) -> bool:
         """Return True if the file exists on disk and overwrite is False.
-
+ 
         Parameters
         ----------
         local_path : absolute path to the expected local file.
-
+ 
         Returns
         -------
         bool
             True if the file should be skipped (exists and overwrite=False).
         """
         return (not self.overwrite) and os.path.isfile(local_path)
-
+ 
     @staticmethod
     def _download_file(url: str, local_path: str) -> None:
         """Stream url to local_path with a tqdm progress bar.
-
+ 
+        Downloads to a temporary file first and renames it to local_path
+        only after the download completes successfully. This prevents
+        corrupt partial files from being left on disk if the download
+        fails or is interrupted mid-way. If the download fails, the
+        temporary file is deleted automatically.
+ 
         Parameters
         ----------
         url        : remote URL to fetch.
         local_path : destination file path (parent directory must exist).
-
+ 
         Raises
         ------
         requests.exceptions.RequestException
             Propagated from requests on any HTTP or connection error.
         """
-        with requests.get(url, stream=True, timeout=120) as response:
-            response.raise_for_status()
-            total_size = int(response.headers.get("content-length", 0))
-            with open(local_path, "wb") as fh, tqdm(
-                desc=os.path.basename(local_path),
-                total=total_size,
-                unit="iB",
-                unit_scale=True,
-                unit_divisor=1024,
-            ) as bar:
-                for chunk in response.iter_content(chunk_size=8192):
-                    size = fh.write(chunk)
-                    bar.update(size)
-
+        tmp_path = local_path + ".tmp"
+        try:
+            with requests.get(url, stream=True, timeout=120) as response:
+                response.raise_for_status()
+                total_size = int(response.headers.get("content-length", 0))
+                with open(tmp_path, "wb") as fh, tqdm(
+                    desc=os.path.basename(local_path),
+                    total=total_size,
+                    unit="iB",
+                    unit_scale=True,
+                    unit_divisor=1024,
+                ) as bar:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        size = fh.write(chunk)
+                        bar.update(size)
+            os.replace(tmp_path, local_path)
+        except Exception:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
+ 
     @staticmethod
     def unzip_file(zip_path: str) -> None:
         """Extract a zip archive to its parent directory and delete the zip.
-
+ 
         Cleans up any __MACOSX metadata folder that macOS-created archives
         may include.
-
+ 
         Parameters
         ----------
         zip_path : path to the zip file to extract.
@@ -167,14 +180,14 @@ class Downloader:
         extract_dir = os.path.dirname(zip_path)
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(extract_dir)
-
+ 
         # Remove __MACOSX metadata folder if present
         macosx_path = os.path.join(extract_dir, "__MACOSX")
         if os.path.exists(macosx_path) and os.path.isdir(macosx_path):
             shutil.rmtree(macosx_path)
-
+ 
         os.remove(zip_path)
-
+ 
     def download_parallel(
         self,
         url_path_pairs: list,
@@ -182,17 +195,17 @@ class Downloader:
         dryrun: bool = False,
     ) -> tuple:
         """Download multiple (url, local_path) pairs concurrently.
-
+ 
         Uses ThreadPoolExecutor to call _download_file() for each pair.
         Logs progress and returns counts of completed and failed downloads.
-
+ 
         Parameters
         ----------
         url_path_pairs : list of (url, local_path) tuples to download.
         num_threads    : number of concurrent download threads.
         dryrun         : if True, log what would be downloaded without
                          fetching anything.
-
+ 
         Returns
         -------
         tuple
@@ -204,21 +217,21 @@ class Downloader:
             len(url_path_pairs),
             actual_threads,
         )
-
+ 
         if dryrun:
             for url, local_path in url_path_pairs:
                 logging.info("DRY RUN: Would download %s to %s", url, local_path)
             return len(url_path_pairs), 0
-
+ 
         completed = 0
         failed = 0
-
+ 
         with ThreadPoolExecutor(max_workers=actual_threads) as executor:
             future_to_url = {
                 executor.submit(self._download_file, url, local_path): url
                 for url, local_path in url_path_pairs
             }
-
+ 
             for future in as_completed(future_to_url):
                 url = future_to_url[future]
                 try:
@@ -228,12 +241,12 @@ class Downloader:
                 except Exception as exc:
                     failed += 1
                     logging.error("Failed to download %s: %s", url, exc)
-
+ 
         logging.info(
             "Download completed. Success: %d, Failed: %d", completed, failed
         )
         return completed, failed
-
+ 
 ##########################################################################
 if __name__ == "__main__":
     Downloader()

--- a/crocolaketools/downloader/downloader.py
+++ b/crocolaketools/downloader/downloader.py
@@ -22,6 +22,10 @@ import yaml
 from tqdm import tqdm
 
 from crocolakeloader import params
+
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 ##########################################################################
 
 
@@ -171,7 +175,64 @@ class Downloader:
             shutil.rmtree(macosx_path)
 
         os.remove(zip_path)
-
+    
+    def download_parallel(
+        self,
+        url_path_pairs: list,
+        num_threads: int = 4,
+        dryrun: bool = False,
+    ) -> tuple:
+        """Download multiple (url, local_path) pairs concurrently.
+ 
+        Uses ThreadPoolExecutor to call _download_file() for each pair.
+        Logs progress and returns counts of completed and failed downloads.
+ 
+        Parameters
+        ----------
+        url_path_pairs : list of (url, local_path) tuples to download.
+        num_threads    : number of concurrent download threads.
+        dryrun         : if True, log what would be downloaded without
+                         fetching anything.
+ 
+        Returns
+        -------
+        tuple
+            (completed, failed) counts.
+        """
+        logging.info(
+            "Starting parallel download of %d files with %d threads",
+            len(url_path_pairs),
+            num_threads,
+        )
+ 
+        if dryrun:
+            for url, local_path in url_path_pairs:
+                logging.info("DRY RUN: Would download %s to %s", url, local_path)
+            return len(url_path_pairs), 0
+ 
+        completed = 0
+        failed = 0
+ 
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            future_to_url = {
+                executor.submit(self._download_file, url, local_path): url
+                for url, local_path in url_path_pairs
+            }
+ 
+            for future in as_completed(future_to_url):
+                url = future_to_url[future]
+                try:
+                    future.result()
+                    completed += 1
+                    logging.info("Downloaded %s", url)
+                except Exception as exc:
+                    failed += 1
+                    logging.error("Failed to download %s: %s", url, exc)
+ 
+        logging.info(
+            "Download completed. Success: %d, Failed: %d", completed, failed
+        )
+        return completed, failed
 ##########################################################################
 if __name__ == "__main__":
     Downloader()

--- a/crocolaketools/downloader/downloaderOleanderXBT.py
+++ b/crocolaketools/downloader/downloaderOleanderXBT.py
@@ -2,46 +2,77 @@
 
 ## @file downloaderOleanderXBT.py
 #
-# Downloader for OleanderXBT netCDF files
+# Downloader for OleanderXBT netCDF files.
 #
 ## @author David Nady <davidnady4yad@gmail.com>
 #         Adapted from Enrico Milanese <enrico.milanese@whoi.edu>
+#         Refactored by mahi-anol
 #
 ## @date Wed 23 Jul 2025
 
 ##########################################################################
-import os
-import requests
 import logging
-import zipfile
-import shutil
-import time
+import os
+import re
+import html as html_module
 from urllib.parse import urlparse
-from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import requests
+
 from crocolaketools.downloader.downloader import Downloader
 ##########################################################################
 
+# Base ERDDAP URL for OleanderXBT files
+OLEANDER_BASE_URL = (
+    "http://erddap.oleander.bios.edu:8080/erddap/files/oleanderXbtNcFiles"
+)
+##########################################################################
+
+
 class DownloaderURLList(Downloader):
-    """class DownloaderURLList: methods to download files from a URL list"""
+    """class DownloaderURLList: build and download a list of OleanderXBT URLs.
+
+    This class handles OleanderXBT-specific logic: resolving which years
+    are available on the ERDDAP server, constructing the zip URLs for
+    each year, and calling the shared download_parallel() and unzip_file()
+    methods from the Downloader base class.
+
+    The base class provides all shared tools: _download_file(), unzip_file(),
+    _is_already_downloaded(), and download_parallel().
+
+    Typical usage
+    -------------
+    >>> downloader = DownloaderURLList(urls=urls, num_threads=4)
+    >>> downloader.download()
+    """
 
     # ------------------------------------------------------------------ #
     # Constructors/Destructors                                           #
     # ------------------------------------------------------------------ #
 
-    def __init__(self, urls, log_file="oleanderXBT_download.log", num_threads=4, overwrite=False, dryrun=False, config=None, base_dir=None):
-        """Initialize the DownloaderURLList instance with configuration.
+    def __init__(
+        self,
+        urls: list,
+        log_file: str = "oleanderXBT_download.log",
+        num_threads: int = 4,
+        overwrite: bool = False,
+        dryrun: bool = False,
+        config: dict = None,
+        base_dir: str = None,
+    ):
+        """Constructor.
 
-        Args:
-            urls (list[str]): URLs to download.
-            log_file (str): Log file path.
-            num_threads (int): Number of download threads.
-            overwrite (bool): Overwrite existing extracted files.
-            dryrun (bool): If True, don't download.
-            config (dict): Optional config with at least {'db','db_type'} and
-                           optionally 'input_path'. If not provided, defaults
-                           to OleanderXBT PHY using package config.yaml.
-            base_dir (str): Optional explicit destination directory; if None,
-                            uses resolved input_path from base class.
+        Arguments
+        ---------
+        urls        : list of zip file URLs to download.
+        log_file    : path to log file.
+        num_threads : number of concurrent download threads.
+        overwrite   : if True, re-download files even if already present.
+        dryrun      : if True, log what would be downloaded without fetching.
+        config      : optional config dict with at least {'db', 'db_type'}.
+                      Defaults to OleanderXBT PHY from config.yaml.
+        base_dir    : optional destination directory. If None, uses the
+                      input_path resolved by the base Downloader.
         """
         if config is None:
             config = {
@@ -49,136 +80,160 @@ class DownloaderURLList(Downloader):
                 'db_type': 'PHY',
             }
         super().__init__(config)
+
         self.urls = urls
         self.base_dir = base_dir if base_dir is not None else self.input_path
         self.log_file = log_file
         self.num_threads = num_threads
         self.overwrite = overwrite
         self.dryrun = dryrun
-        self.configure_logging(self.log_file)
+        self._configure_logging(self.log_file)
 
     # ------------------------------------------------------------------ #
-    # Methods                                                            #
+    # Public interface                                                     #
     # ------------------------------------------------------------------ #
 
-#------------------------------------------------------------------------------#
-## Set up logging to file and console
-    def configure_logging(self, log_file):
-        """Configure logging to both file and console.
+    def download(self) -> tuple:
+        """Download all URLs, unzip each archive, and return (completed, failed).
 
-        Args:
-            log_file (str): Path to the log file.
+        For each URL, the zip is downloaded to base_dir, then extracted
+        via the inherited unzip_file() method (which also deletes the zip
+        and cleans up __MACOSX folders).
+
+        Files whose corresponding NetCDF output already exists on disk are
+        skipped unless overwrite=True.
+
+        Returns
+        -------
+        tuple
+            (completed, failed) counts.
         """
-        # Avoid adding handlers multiple times if called repeatedly
+        # Build (url, local_zip_path) pairs, skipping already-present files
+        url_path_pairs = []
+        for url in self.urls:
+            zip_fname = os.path.basename(urlparse(url).path)
+            zip_path  = os.path.join(self.base_dir, zip_fname)
+
+            if not self.overwrite and self._nc_files_exist(zip_path):
+                logging.info(
+                    "NetCDF files for %s already exist, skipping.", zip_fname
+                )
+                continue
+
+            url_path_pairs.append((url, zip_path))
+
+        if not url_path_pairs:
+            logging.info("Nothing to download.")
+            return 0, 0
+
+        # Download all zips in parallel using the base class method
+        completed, failed = self.download_parallel(
+            url_path_pairs,
+            num_threads=self.num_threads,
+            dryrun=self.dryrun,
+        )
+
+        # Extract each downloaded zip
+        if not self.dryrun:
+            for _url, zip_path in url_path_pairs:
+                if os.path.isfile(zip_path):
+                    try:
+                        self.unzip_file(zip_path)
+                    except Exception as exc:
+                        logging.error(
+                            "Failed to extract %s: %s", zip_path, exc
+                        )
+
+        return completed, failed
+
+    # ------------------------------------------------------------------ #
+    # Private helpers                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _nc_files_exist(self, zip_path: str) -> bool:
+        """Return True if NetCDF files for this zip already exist locally.
+
+        Checks the destination directory for .nc files whose names start
+        with the same year prefix as the zip filename.
+
+        Parameters
+        ----------
+        zip_path : expected local path of the zip archive.
+        """
+        extract_dir = os.path.dirname(zip_path)
+        year = os.path.basename(zip_path)[:4]
+        if not os.path.exists(extract_dir):
+            return False
+        return any(
+            f.endswith('.nc') and f.startswith(year)
+            for f in os.listdir(extract_dir)
+        )
+
+    @staticmethod
+    def _configure_logging(log_file: str) -> None:
+        """Set up logging to both file and console.
+
+        Parameters
+        ----------
+        log_file : path to the log file.
+        """
         if not logging.getLogger().handlers:
             logging.basicConfig(
                 level=logging.INFO,
                 format='%(asctime)s - %(levelname)s - %(message)s',
                 handlers=[
                     logging.FileHandler(log_file),
-                    logging.StreamHandler()
-                ]
+                    logging.StreamHandler(),
+                ],
             )
 
-#------------------------------------------------------------------------------#
-## Unzip file and delete the original zip
-    def unzip_file(self, zip_path):
-        """Unzip a file and delete the original zip file, and clean up __MACOSX folders.
+    # ------------------------------------------------------------------ #
+    # Class methods (OleanderXBT-specific URL building)                   #
+    # ------------------------------------------------------------------ #
 
-        Args:
-            zip_path (str): Path to the zip file.
+    @staticmethod
+    def get_available_years(base_url: str = OLEANDER_BASE_URL) -> list:
+        """Query the ERDDAP directory listing and return available years.
+
+        Parameters
+        ----------
+        base_url : ERDDAP files base URL for OleanderXBT.
+
+        Returns
+        -------
+        list of int
+            Sorted list of years for which zip files are available.
         """
-        extract_dir = os.path.dirname(zip_path)
-        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-            zip_ref.extractall(extract_dir)
-
-        # Remove the __MACOSX directory if it exists
-        macosx_path = os.path.join(extract_dir, "__MACOSX")
-        if os.path.exists(macosx_path) and os.path.isdir(macosx_path):
-            shutil.rmtree(macosx_path)
-
-        os.remove(zip_path)
-
-#------------------------------------------------------------------------------#
-## Download, save and unzip files
-    def download_file(self, url, output_path):
-        """Download a file, save it, then unzip and delete the zip.
-
-        Args:
-            url (str): URL of the file to download.
-            output_path (str): Path where the file will be saved.
-
-        Returns:
-            bool: True if download and unzip succeeded, False otherwise.
-        """
-        if self.dryrun:
-            logging.info("DRY RUN: Would download %s to %s", url, output_path)
-            return True
-
-        # Check if .nc files from this zip already exist
-        if not self.overwrite:
-            extract_dir = os.path.dirname(output_path)
-            year = os.path.basename(output_path)[:4]  # Extract year from zip filename
-            if os.path.exists(extract_dir) and any(f.endswith('.nc') and f.startswith(year) for f in os.listdir(extract_dir)):
-                logging.info("NetCDF files from %s already exist and overwrite is False. Skipping.", output_path)
-                return True
-
         try:
-            response = requests.get(url, stream=True)
-            response.raise_for_status()  # Will raise an exception for HTTP errors
+            response = requests.get(base_url, timeout=30)
+            response.raise_for_status()
+            html_text = html_module.unescape(response.text)
+            year_matches = re.findall(r'(\d{4})_xbt_nc\.zip', html_text)
+            return sorted(set(int(y) for y in year_matches if y.isdigit() and len(y) == 4))
+        except requests.RequestException as exc:
+            logging.error("Error fetching directory listing: %s", exc)
+            return []
 
-            # Check content type to ensure it's not an HTML error page (indicating file not found)
-            content_type = response.headers.get('Content-Type', '').lower()
-            if 'text/html' in content_type:
-                logging.info("File not found (returned HTML), skipping %s", url)
-                return False
+    @staticmethod
+    def build_urls(
+        years: list,
+        base_url: str = OLEANDER_BASE_URL,
+    ) -> list:
+        """Build download URLs for the given list of years.
 
-            with open(output_path, 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
+        Parameters
+        ----------
+        years    : list of years to build URLs for.
+        base_url : ERDDAP files base URL for OleanderXBT.
 
-            logging.info("Downloaded %s to %s", url, output_path)
+        Returns
+        -------
+        list of str
+            One zip URL per year.
+        """
+        return [f"{base_url}/{year}_xbt_nc.zip" for year in years]
 
-            # Unzip and delete the zip file
-            self.unzip_file(output_path)
-            return True
-        
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError, requests.exceptions.RequestException) as e:
-            logging.error("Error downloading %s: %s", url, str(e))
-            return False
-        
-        except Exception as e:
-            logging.error("Unexpected error downloading %s: %s", url, str(e))
-            return False
+##########################################################################
 
-#------------------------------------------------------------------------------#
-## Download files from URL list using multithreading
-    def url_list_download(self):
-        """Download files from a list of URLs."""
-        logging.info("Starting download of %d files with %d threads", len(self.urls), self.num_threads)
-
-        with ThreadPoolExecutor(max_workers=self.num_threads) as executor:
-            future_to_url = {
-                executor.submit(
-                    self.download_file, 
-                    url, 
-                    os.path.join(self.base_dir, os.path.basename(urlparse(url).path))
-                ): url
-                for url in self.urls
-            }
-
-            completed = 0
-            failed = 0
-            for future in as_completed(future_to_url):
-                url = future_to_url[future]
-                try:
-                    if future.result():
-                        completed += 1
-                    else:
-                        failed += 1
-                except Exception as e:
-                    failed += 1
-                    logging.error("Error processing %s: %s", url, e)
-
-        logging.info("Download completed. Success: %d, Failed: %d", completed, failed)
-        return failed == 0
+if __name__ == "__main__":
+    DownloaderURLList(urls=[])

--- a/crocolaketools/downloader/downloaderOleanderXBT.py
+++ b/crocolaketools/downloader/downloaderOleanderXBT.py
@@ -6,7 +6,7 @@
 #
 ## @author David Nady <davidnady4yad@gmail.com>
 #         Adapted from Enrico Milanese <enrico.milanese@whoi.edu>
-#         Refactored by Mahi Sarwar Anol <anol.mahi@gmail.com>
+#         Refactored by mahi-anol
 #
 ## @date Wed 23 Jul 2025
 
@@ -139,6 +139,8 @@ class DownloaderURLList(Downloader):
                 if os.path.isfile(zip_path):
                     try:
                         self.unzip_file(zip_path)
+                        logging.info("Extracted %s", zip_path)
+                        print(f"Extracted {os.path.basename(zip_path)}")
                     except Exception as exc:
                         logging.error(
                             "Failed to extract %s: %s", zip_path, exc

--- a/crocolaketools/downloader/downloaderOleanderXBT.py
+++ b/crocolaketools/downloader/downloaderOleanderXBT.py
@@ -82,7 +82,7 @@ class DownloaderURLList(Downloader):
         super().__init__(config)
 
         self.urls = urls
-        self.base_dir = base_dir if base_dir is not None else self.input_path
+        self.base_dir = base_dir if base_dir is not None else getattr(self, 'input_path', None)
         self.log_file = log_file
         self.num_threads = num_threads
         self.overwrite = overwrite

--- a/crocolaketools/downloader/downloaderOleanderXBT.py
+++ b/crocolaketools/downloader/downloaderOleanderXBT.py
@@ -218,6 +218,63 @@ class DownloaderURLList(Downloader):
             One zip URL per year.
         """
         return [f"{base_url}/{year}_xbt_nc.zip" for year in years]
+    
+    @staticmethod
+    def resolve_urls(
+        url_file: str = None,
+        start_year: int = None,
+        end_year: int = None,
+        base_url: str = OLEANDER_BASE_URL,
+    ) -> list:
+        """Resolve the list of URLs to download based on user arguments.
+ 
+        Handles three cases:
+        - url_file provided: read URLs from file
+        - start_year and end_year provided: build URLs for that year range
+        - neither provided: prompt user and download all available years
+ 
+        Parameters
+        ----------
+        url_file   : path to a text file containing one URL per line.
+        start_year : first year to download (inclusive).
+        end_year   : last year to download (inclusive).
+        base_url   : ERDDAP base URL for OleanderXBT.
+ 
+        Returns
+        -------
+        list of str
+            URLs to download, or empty list if cancelled.
+        """
+        available_years = DownloaderURLList.get_available_years(base_url)
+ 
+        if not available_years:
+            print("Could not fetch available years from the server. Exiting.")
+            return []
+ 
+        min_year = min(available_years)
+        max_year = max(available_years)
+ 
+        if url_file:
+            with open(url_file, 'r') as f:
+                return [url.strip() for url in f if url.strip()]
+ 
+        elif start_year and end_year:
+            adjusted = max(start_year, min_year)
+            if start_year < min_year:
+                print(f"Warning: start year {start_year} is before {min_year}. Adjusting.")
+            years = range(adjusted, end_year + 1)
+            return DownloaderURLList.build_urls(years, base_url)
+ 
+        else:
+            print(
+                f"\nWarning: No --url_file or --start_year/--end_year provided. "
+                f"Defaulting to all available years ({min_year}-{max_year})."
+            )
+            response = input("Do you want to continue? (y/N): ").strip().lower()
+            if response != 'y':
+                print("Download cancelled.")
+                return []
+            return DownloaderURLList.build_urls(available_years, base_url)
  
 ##########################################################################
  

--- a/crocolaketools/downloader/downloaderOleanderXBT.py
+++ b/crocolaketools/downloader/downloaderOleanderXBT.py
@@ -6,7 +6,7 @@
 #
 ## @author David Nady <davidnady4yad@gmail.com>
 #         Adapted from Enrico Milanese <enrico.milanese@whoi.edu>
-#         Refactored by mahi-anol
+#         Refactored by Mahi Sarwar Anol <anol.mahi@gmail.com>
 #
 ## @date Wed 23 Jul 2025
 

--- a/crocolaketools/downloader/downloaderOleanderXBT.py
+++ b/crocolaketools/downloader/downloaderOleanderXBT.py
@@ -16,40 +16,40 @@ import os
 import re
 import html as html_module
 from urllib.parse import urlparse
-
+ 
 import requests
-
+ 
 from crocolaketools.downloader.downloader import Downloader
 ##########################################################################
-
+ 
 # Base ERDDAP URL for OleanderXBT files
 OLEANDER_BASE_URL = (
     "http://erddap.oleander.bios.edu:8080/erddap/files/oleanderXbtNcFiles"
 )
 ##########################################################################
-
-
+ 
+ 
 class DownloaderURLList(Downloader):
     """class DownloaderURLList: build and download a list of OleanderXBT URLs.
-
+ 
     This class handles OleanderXBT-specific logic: resolving which years
     are available on the ERDDAP server, constructing the zip URLs for
     each year, and calling the shared download_parallel() and unzip_file()
     methods from the Downloader base class.
-
+ 
     The base class provides all shared tools: _download_file(), unzip_file(),
     _is_already_downloaded(), and download_parallel().
-
+ 
     Typical usage
     -------------
     >>> downloader = DownloaderURLList(urls=urls, num_threads=4)
     >>> downloader.download()
     """
-
+ 
     # ------------------------------------------------------------------ #
     # Constructors/Destructors                                           #
     # ------------------------------------------------------------------ #
-
+ 
     def __init__(
         self,
         urls: list,
@@ -61,7 +61,7 @@ class DownloaderURLList(Downloader):
         base_dir: str = None,
     ):
         """Constructor.
-
+ 
         Arguments
         ---------
         urls        : list of zip file URLs to download.
@@ -80,29 +80,30 @@ class DownloaderURLList(Downloader):
                 'db_type': 'PHY',
             }
         super().__init__(config)
-
+ 
         self.urls = urls
         self.base_dir = base_dir if base_dir is not None else getattr(self, 'input_path', None)
         self.log_file = log_file
+        # Override base class defaults with subclass-specific values
         self.num_threads = num_threads
         self.overwrite = overwrite
         self.dryrun = dryrun
         self._configure_logging(self.log_file)
-
+ 
     # ------------------------------------------------------------------ #
     # Public interface                                                     #
     # ------------------------------------------------------------------ #
-
+ 
     def download(self) -> tuple:
         """Download all URLs, unzip each archive, and return (completed, failed).
-
+ 
         For each URL, the zip is downloaded to base_dir, then extracted
         via the inherited unzip_file() method (which also deletes the zip
         and cleans up __MACOSX folders).
-
+ 
         Files whose corresponding NetCDF output already exists on disk are
         skipped unless overwrite=True.
-
+ 
         Returns
         -------
         tuple
@@ -113,26 +114,26 @@ class DownloaderURLList(Downloader):
         for url in self.urls:
             zip_fname = os.path.basename(urlparse(url).path)
             zip_path  = os.path.join(self.base_dir, zip_fname)
-
+ 
             if not self.overwrite and self._nc_files_exist(zip_path):
                 logging.info(
                     "NetCDF files for %s already exist, skipping.", zip_fname
                 )
                 continue
-
+ 
             url_path_pairs.append((url, zip_path))
-
+ 
         if not url_path_pairs:
             logging.info("Nothing to download.")
             return 0, 0
-
+ 
         # Download all zips in parallel using the base class method
         completed, failed = self.download_parallel(
             url_path_pairs,
             num_threads=self.num_threads,
             dryrun=self.dryrun,
         )
-
+ 
         # Extract each downloaded zip
         if not self.dryrun:
             for _url, zip_path in url_path_pairs:
@@ -145,19 +146,19 @@ class DownloaderURLList(Downloader):
                         logging.error(
                             "Failed to extract %s: %s", zip_path, exc
                         )
-
+ 
         return completed, failed
-
+ 
     # ------------------------------------------------------------------ #
     # Private helpers                                                      #
     # ------------------------------------------------------------------ #
-
+ 
     def _nc_files_exist(self, zip_path: str) -> bool:
         """Return True if NetCDF files for this zip already exist locally.
-
+ 
         Checks the destination directory for .nc files whose names start
         with the same year prefix as the zip filename.
-
+ 
         Parameters
         ----------
         zip_path : expected local path of the zip archive.
@@ -170,11 +171,11 @@ class DownloaderURLList(Downloader):
             f.endswith('.nc') and f.startswith(year)
             for f in os.listdir(extract_dir)
         )
-
+ 
     @staticmethod
     def _configure_logging(log_file: str) -> None:
         """Set up logging to both file and console.
-
+ 
         Parameters
         ----------
         log_file : path to the log file.
@@ -188,19 +189,19 @@ class DownloaderURLList(Downloader):
                     logging.StreamHandler(),
                 ],
             )
-
+ 
     # ------------------------------------------------------------------ #
     # Class methods (OleanderXBT-specific URL building)                   #
     # ------------------------------------------------------------------ #
-
+ 
     @staticmethod
     def get_available_years(base_url: str = OLEANDER_BASE_URL) -> list:
         """Query the ERDDAP directory listing and return available years.
-
+ 
         Parameters
         ----------
         base_url : ERDDAP files base URL for OleanderXBT.
-
+ 
         Returns
         -------
         list of int
@@ -215,27 +216,27 @@ class DownloaderURLList(Downloader):
         except requests.RequestException as exc:
             logging.error("Error fetching directory listing: %s", exc)
             return []
-
+ 
     @staticmethod
     def build_urls(
         years: list,
         base_url: str = OLEANDER_BASE_URL,
     ) -> list:
         """Build download URLs for the given list of years.
-
+ 
         Parameters
         ----------
         years    : list of years to build URLs for.
         base_url : ERDDAP files base URL for OleanderXBT.
-
+ 
         Returns
         -------
         list of str
             One zip URL per year.
         """
         return [f"{base_url}/{year}_xbt_nc.zip" for year in years]
-
+ 
 ##########################################################################
-
+ 
 if __name__ == "__main__":
     DownloaderURLList(urls=[])

--- a/crocolaketools/downloader/downloaderOleanderXBT.py
+++ b/crocolaketools/downloader/downloaderOleanderXBT.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 import requests
  
 from crocolaketools.downloader.downloader import Downloader
+from crocolaketools.utils.logger_configurator import configure_logging
 ##########################################################################
  
 # Base ERDDAP URL for OleanderXBT files
@@ -88,7 +89,7 @@ class DownloaderURLList(Downloader):
         self.num_threads = num_threads
         self.overwrite = overwrite
         self.dryrun = dryrun
-        self._configure_logging(self.log_file)
+        configure_logging(self.log_file)
  
     # ------------------------------------------------------------------ #
     # Public interface                                                     #
@@ -171,25 +172,7 @@ class DownloaderURLList(Downloader):
             f.endswith('.nc') and f.startswith(year)
             for f in os.listdir(extract_dir)
         )
- 
-    @staticmethod
-    def _configure_logging(log_file: str) -> None:
-        """Set up logging to both file and console.
- 
-        Parameters
-        ----------
-        log_file : path to the log file.
-        """
-        if not logging.getLogger().handlers:
-            logging.basicConfig(
-                level=logging.INFO,
-                format='%(asctime)s - %(levelname)s - %(message)s',
-                handlers=[
-                    logging.FileHandler(log_file),
-                    logging.StreamHandler(),
-                ],
-            )
- 
+
     # ------------------------------------------------------------------ #
     # Class methods (OleanderXBT-specific URL building)                   #
     # ------------------------------------------------------------------ #

--- a/crocolaketools/test/test_downloaderOleanderXBT.py
+++ b/crocolaketools/test/test_downloaderOleanderXBT.py
@@ -171,9 +171,7 @@ class TestDownload:
                           return_value=(2, 0)) as mock_parallel:
             d.download()
             _, kwargs = mock_parallel.call_args
-            assert mock_parallel.call_args[1].get("dryrun", True) or \
-                   mock_parallel.call_args[0][2] is True or \
-                   d.dryrun is True
+            assert kwargs.get("dryrun") is True
 
     def test_overwrite_downloads_even_if_nc_exists(self, tmp_path, mock_base_downloader):
         """All URLs are queued even if .nc files exist when overwrite=True."""
@@ -209,15 +207,16 @@ class TestDownload:
 
 @pytest.fixture
 def mock_base_downloader():
-    """Patch Downloader.__init__ so tests don't need config.yaml."""
+    """Patch Downloader.__init__ and configure_logging so tests don't need
+    config.yaml or write log files to disk."""
     with patch(
         "crocolaketools.downloader.downloaderOleanderXBT.Downloader.__init__",
         return_value=None,
+    ), patch(
+        "crocolaketools.downloader.downloaderOleanderXBT.configure_logging",
     ):
         # input_path is set by Downloader.__init__ normally.
-        # Since we mock it out, we patch input_path on the instance
-        # via the constructor post-init in each test that needs it.
-        # Tests that need input_path set it manually: d.input_path = ...
+        # Since we mock it out, tests that need it set it manually: d.input_path = ...
         yield
 
 

--- a/crocolaketools/test/test_downloaderOleanderXBT.py
+++ b/crocolaketools/test/test_downloaderOleanderXBT.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+
+## @file test_downloaderOleanderXBT.py
+#
+#
+## @author mahi-anol
+#
+## @date Mon 30 Mar 2026
+
+##########################################################################
+import os
+import zipfile
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+import requests
+
+from crocolaketools.downloader.downloaderOleanderXBT import (
+    OLEANDER_BASE_URL,
+    DownloaderURLList,
+)
+##########################################################################
+
+DUMMY_URLS = [
+    f"{OLEANDER_BASE_URL}/2022_xbt_nc.zip",
+    f"{OLEANDER_BASE_URL}/2023_xbt_nc.zip",
+]
+
+
+class TestDownloaderURLListInit:
+    """Tests for DownloaderURLList.__init__"""
+
+    def test_defaults(self, mock_base_downloader):
+        """Constructor stores correct defaults."""
+        d = DownloaderURLList(urls=DUMMY_URLS)
+        assert d.urls == DUMMY_URLS
+        assert d.num_threads == 4
+        assert d.overwrite is False
+        assert d.dryrun is False
+
+    def test_custom_args(self, mock_base_downloader):
+        """Constructor stores custom arguments."""
+        d = DownloaderURLList(
+            urls=DUMMY_URLS,
+            num_threads=8,
+            overwrite=True,
+            dryrun=True,
+        )
+        assert d.num_threads == 8
+        assert d.overwrite is True
+        assert d.dryrun is True
+
+    def test_inherits_downloader(self):
+        """DownloaderURLList is a subclass of Downloader."""
+        from crocolaketools.downloader.downloader import Downloader
+        assert issubclass(DownloaderURLList, Downloader)
+
+    def test_default_config_is_oleanderxbt_phy(self, mock_base_downloader):
+        """When no config given, base class called with OleanderXBT/PHY."""
+        with patch(
+            "crocolaketools.downloader.downloaderOleanderXBT.Downloader.__init__"
+        ) as mock_super:
+            mock_super.return_value = None
+            DownloaderURLList(urls=[])
+            called_config = mock_super.call_args[0][0]
+            assert called_config['db'] == 'OleanderXBT'
+            assert called_config['db_type'] == 'PHY'
+
+
+class TestNcFilesExist:
+    """Tests for DownloaderURLList._nc_files_exist"""
+
+    def test_returns_true_when_nc_exists(self, tmp_path, mock_base_downloader):
+        """Returns True when matching .nc files are present."""
+        (tmp_path / "2022_data.nc").write_bytes(b"data")
+        d = DownloaderURLList(urls=[])
+        zip_path = str(tmp_path / "2022_xbt_nc.zip")
+        assert d._nc_files_exist(zip_path) is True
+
+    def test_returns_false_when_no_nc(self, tmp_path, mock_base_downloader):
+        """Returns False when no matching .nc files are present."""
+        d = DownloaderURLList(urls=[])
+        zip_path = str(tmp_path / "2022_xbt_nc.zip")
+        assert d._nc_files_exist(zip_path) is False
+
+    def test_returns_false_when_dir_missing(self, tmp_path, mock_base_downloader):
+        """Returns False when the extract directory does not exist."""
+        d = DownloaderURLList(urls=[])
+        zip_path = str(tmp_path / "nonexistent" / "2022_xbt_nc.zip")
+        assert d._nc_files_exist(zip_path) is False
+
+
+class TestGetAvailableYears:
+    """Tests for DownloaderURLList.get_available_years"""
+
+    def test_parses_years_from_html(self):
+        """Extracts years correctly from ERDDAP directory listing HTML."""
+        fake_html = (
+            '<a href="2021_xbt_nc.zip">2021_xbt_nc.zip</a>'
+            '<a href="2022_xbt_nc.zip">2022_xbt_nc.zip</a>'
+            '<a href="2023_xbt_nc.zip">2023_xbt_nc.zip</a>'
+        )
+        mock_resp = MagicMock()
+        mock_resp.text = fake_html
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("crocolaketools.downloader.downloaderOleanderXBT.requests.get",
+                   return_value=mock_resp):
+            years = DownloaderURLList.get_available_years()
+
+        assert years == [2021, 2022, 2023]
+
+    def test_returns_empty_on_connection_error(self):
+        """Returns empty list when server is unreachable."""
+        with patch("crocolaketools.downloader.downloaderOleanderXBT.requests.get",
+                   side_effect=requests.RequestException("down")):
+            years = DownloaderURLList.get_available_years()
+        assert years == []
+
+
+class TestBuildUrls:
+    """Tests for DownloaderURLList.build_urls"""
+
+    def test_builds_correct_urls(self):
+        """Constructs correct zip URLs for given years."""
+        urls = DownloaderURLList.build_urls([2021, 2022])
+        assert urls == [
+            f"{OLEANDER_BASE_URL}/2021_xbt_nc.zip",
+            f"{OLEANDER_BASE_URL}/2022_xbt_nc.zip",
+        ]
+
+
+class TestDownload:
+    """Tests for DownloaderURLList.download"""
+
+    def test_skips_existing_nc_files(self, tmp_path, mock_base_downloader):
+        """No download attempted when .nc files already exist and overwrite=False."""
+        d = DownloaderURLList(urls=DUMMY_URLS, overwrite=False)
+        d.base_dir = str(tmp_path) + "/"
+        # Create existing .nc file for 2022
+        (tmp_path / "2022_data.nc").write_bytes(b"data")
+
+        with patch.object(DownloaderURLList, "download_parallel",
+                          return_value=(0, 0)) as mock_parallel:
+            d.download()
+            # Only 2023 should be queued (2022 already has .nc files)
+            args = mock_parallel.call_args[0][0]
+            assert len(args) == 1
+            assert "2023" in args[0][0]
+
+    def test_downloads_all_when_nothing_present(self, tmp_path, mock_base_downloader):
+        """All URLs are queued when no .nc files exist locally."""
+        d = DownloaderURLList(urls=DUMMY_URLS)
+        d.base_dir = str(tmp_path) + "/"
+
+        with patch.object(DownloaderURLList, "download_parallel",
+                          return_value=(2, 0)) as mock_parallel, \
+             patch.object(DownloaderURLList, "unzip_file"):
+            completed, failed = d.download()
+            assert mock_parallel.call_args[0][0] == [
+                (DUMMY_URLS[0], os.path.join(d.base_dir, "2022_xbt_nc.zip")),
+                (DUMMY_URLS[1], os.path.join(d.base_dir, "2023_xbt_nc.zip")),
+            ]
+
+    def test_dryrun_skips_actual_download(self, tmp_path, mock_base_downloader):
+        """Dryrun passes through to download_parallel without fetching files."""
+        d = DownloaderURLList(urls=DUMMY_URLS, dryrun=True)
+        d.base_dir = str(tmp_path) + "/"
+
+        with patch.object(DownloaderURLList, "download_parallel",
+                          return_value=(2, 0)) as mock_parallel:
+            d.download()
+            _, kwargs = mock_parallel.call_args
+            assert mock_parallel.call_args[1].get("dryrun", True) or \
+                   mock_parallel.call_args[0][2] is True or \
+                   d.dryrun is True
+
+    def test_overwrite_downloads_even_if_nc_exists(self, tmp_path, mock_base_downloader):
+        """All URLs are queued even if .nc files exist when overwrite=True."""
+        d = DownloaderURLList(urls=DUMMY_URLS, overwrite=True)
+        d.base_dir = str(tmp_path) + "/"
+        (tmp_path / "2022_data.nc").write_bytes(b"data")
+
+        with patch.object(DownloaderURLList, "download_parallel",
+                          return_value=(2, 0)) as mock_parallel, \
+             patch.object(DownloaderURLList, "unzip_file"):
+            d.download()
+            args = mock_parallel.call_args[0][0]
+            assert len(args) == 2
+
+    def test_unzip_called_for_each_downloaded_zip(self, tmp_path, mock_base_downloader):
+        """unzip_file is called for each zip that was successfully downloaded."""
+        d = DownloaderURLList(urls=[DUMMY_URLS[0]])
+        d.base_dir = str(tmp_path) + "/"
+        zip_path = os.path.join(d.base_dir, "2022_xbt_nc.zip")
+
+        # Simulate zip file appearing after download
+        with patch.object(DownloaderURLList, "download_parallel",
+                          return_value=(1, 0)), \
+             patch("os.path.isfile", return_value=True), \
+             patch.object(DownloaderURLList, "unzip_file") as mock_unzip:
+            d.download()
+            mock_unzip.assert_called_once_with(zip_path)
+
+
+##########################################################################
+# Fixtures
+##########################################################################
+
+@pytest.fixture
+def mock_base_downloader():
+    """Patch Downloader.__init__ so tests don't need config.yaml."""
+    with patch(
+        "crocolaketools.downloader.downloaderOleanderXBT.Downloader.__init__",
+        return_value=None,
+    ):
+        # input_path is set by Downloader.__init__ normally.
+        # Since we mock it out, we patch input_path on the instance
+        # via the constructor post-init in each test that needs it.
+        # Tests that need input_path set it manually: d.input_path = ...
+        yield
+
+
+##########################################################################
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/crocolaketools/test/test_downloaderOleanderXBT.py
+++ b/crocolaketools/test/test_downloaderOleanderXBT.py
@@ -3,7 +3,7 @@
 ## @file test_downloaderOleanderXBT.py
 #
 #
-## @author mahi-anol
+## @author Mahi Sarwar Anol <anol.mahi@gmail.com>
 #
 ## @date Mon 30 Mar 2026
 

--- a/scripts/download_oleanderXBT.py
+++ b/scripts/download_oleanderXBT.py
@@ -20,6 +20,61 @@ from crocolaketools.downloader.downloaderOleanderXBT import (
 ##########################################################################
 
 
+def download_oleanderXBT(
+    url_file=None,
+    start_year=None,
+    end_year=None,
+    base_url=OLEANDER_BASE_URL,
+    save_to=None,
+    threads=4,
+    dryrun=False,
+    overwrite=False,
+    log_file="oleanderXBT_download.log",
+):
+    """Resolve URLs and run the OleanderXBT downloader.
+ 
+    Arguments
+    ---------
+    url_file   : path to a text file containing one URL per line.
+    start_year : first year to download (inclusive).
+    end_year   : last year to download (inclusive).
+    base_url   : ERDDAP base URL for OleanderXBT.
+    save_to    : directory to save downloaded files. If None, uses config.yaml.
+    threads    : number of parallel download threads.
+    dryrun     : if True, print summary without downloading.
+    overwrite  : if True, re-download files already present.
+    log_file   : path to log file.
+    """
+    urls = DownloaderURLList.resolve_urls(
+        url_file=url_file,
+        start_year=start_year,
+        end_year=end_year,
+        base_url=base_url,
+    )
+ 
+    if not urls:
+        return
+ 
+    downloader = DownloaderURLList(
+        urls=urls,
+        log_file=log_file,
+        num_threads=threads,
+        overwrite=overwrite,
+        dryrun=dryrun,
+        base_dir=save_to,
+    )
+ 
+    print(f"\nAttempting to download {len(urls)} files to: {downloader.base_dir}")
+    completed, failed = downloader.download()
+ 
+    print("\nOleanderXBT download finished.")
+    if dryrun:
+        print("Dry run complete. No files were actually downloaded.")
+    else:
+        print(f"Success: {completed}  Failed: {failed}")
+        print(f"See '{log_file}' for details.")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Download OleanderXBT data from a list of URLs or by specifying years.'
@@ -75,60 +130,18 @@ def main():
 
     args = parser.parse_args()
 
-    # --- Build URL list (OleanderXBT-specific logic stays in the script) ---
 
-    available_years = DownloaderURLList.get_available_years(args.base_url)
-
-    if not available_years:
-        print("Could not fetch available years from the server. Exiting.")
-        return
-
-    min_year = min(available_years)
-    max_year = max(available_years)
-
-    if args.url_file:
-        with open(args.url_file, 'r') as f:
-            urls = [url.strip() for url in f if url.strip()]
-
-    elif args.start_year and args.end_year:
-        start_year = max(args.start_year, min_year)
-        if args.start_year < min_year:
-            print(f"Warning: start year {args.start_year} is before {min_year}. Adjusting.")
-        years = range(start_year, args.end_year + 1)
-        urls = DownloaderURLList.build_urls(years, args.base_url)
-
-    else:
-        print(
-            f"\nWarning: No --url_file or --start_year/--end_year provided. "
-            f"Defaulting to all available years ({min_year}-{max_year})."
-        )
-        response = input("Do you want to continue? (y/N): ").strip().lower()
-        if response != 'y':
-            print("Download cancelled.")
-            return
-        urls = DownloaderURLList.build_urls(available_years, args.base_url)
-
-    # --- Hand off to the downloader ---
-
-    downloader = DownloaderURLList(
-        urls=urls,
-        log_file=args.log_file,
-        num_threads=args.threads,
-        overwrite=args.overwrite,
+    download_oleanderXBT(
+        url_file=args.url_file,
+        start_year=args.start_year,
+        end_year=args.end_year,
+        base_url=args.base_url,
+        save_to=args.save_to,
+        threads=args.threads,
         dryrun=args.dryrun,
-        base_dir=args.save_to,
+        overwrite=args.overwrite,
+        log_file=args.log_file,
     )
-
-    print(f"\nAttempting to download {len(urls)} files to: {downloader.base_dir}")
-    completed, failed = downloader.download()
-
-    print("\nOleanderXBT download finished.")
-    if args.dryrun:
-        print("Dry run complete. No files were actually downloaded.")
-    else:
-        print(f"Success: {completed}  Failed: {failed}")
-        print(f"See '{args.log_file}' for details.")
-
 
 ##########################################################################
 

--- a/scripts/download_oleanderXBT.py
+++ b/scripts/download_oleanderXBT.py
@@ -21,6 +21,7 @@ from crocolaketools.downloader.downloaderOleanderXBT import (
 
 
 def download_oleanderXBT(
+    config=None,
     url_file=None,
     start_year=None,
     end_year=None,
@@ -35,6 +36,8 @@ def download_oleanderXBT(
  
     Arguments
     ---------
+    config     : configuration dict passed to DownloaderURLList.
+                 If None, uses config.yaml defaults (triggered by --config flag).
     url_file   : path to a text file containing one URL per line.
     start_year : first year to download (inclusive).
     end_year   : last year to download (inclusive).
@@ -61,6 +64,7 @@ def download_oleanderXBT(
         num_threads=threads,
         overwrite=overwrite,
         dryrun=dryrun,
+        config=config,
         base_dir=save_to,
     )
  
@@ -128,10 +132,21 @@ def main():
         help='Path to log file (default: oleanderXBT_download.log).'
     )
 
+    parser.add_argument(
+        '--config',
+        action='store_true',
+        default=False,
+        help=(
+            'Use config.yaml defaults for input_path. '
+            'Can be combined with --start_year and --end_year to filter years.'
+        ),
+    )
     args = parser.parse_args()
 
+    config = None if args.config else {'db': 'OleanderXBT', 'db_type': 'PHY'}
 
     download_oleanderXBT(
+        config=config,
         url_file=args.url_file,
         start_year=args.start_year,
         end_year=args.end_year,

--- a/scripts/download_oleanderXBT.py
+++ b/scripts/download_oleanderXBT.py
@@ -5,144 +5,136 @@
 # CLI for downloading OleanderXBT data.
 #
 ## @author David Nady <davidnady4yad@gmail.com>
+#         Refactored by mahi-anol
 #
 ## @date Wed 23 Jul 2025
 
-############################################################################
+##########################################################################
 import argparse
-import importlib.resources
-import yaml
-from pprint import pprint
-import requests
-import re
-import html
-from crocolaketools.downloader.downloaderOleanderXBT import DownloaderURLList
-############################################################################
+from datetime import datetime
+
+from crocolaketools.downloader.downloaderOleanderXBT import (
+    OLEANDER_BASE_URL,
+    DownloaderURLList,
+)
+##########################################################################
+
 
 def main():
-    parser = argparse.ArgumentParser(description='Download OleanderXBT data from a list of URLs or by specifying years.')
+    parser = argparse.ArgumentParser(
+        description='Download OleanderXBT data from a list of URLs or by specifying years.'
+    )
     parser.add_argument(
-        '-u', 
-        '--url_file', 
+        '-u', '--url_file',
         help='Path to a text file containing a list of URLs to download.'
     )
     parser.add_argument(
-        '--start_year', 
-        type=int, 
+        '--start_year',
+        type=int,
         help='Start year for downloading OleanderXBT data (e.g., 2020).'
     )
     parser.add_argument(
-        '--end_year', 
-        type=int, 
+        '--end_year',
+        type=int,
         help='End year for downloading OleanderXBT data (e.g., 2024).'
     )
     parser.add_argument(
         '--base_url',
         type=str,
-        default="http://erddap.oleander.bios.edu:8080/erddap/files/oleanderXbtNcFiles",
-        help="The base URL for constructing download links for year-based downloads."
+        default=OLEANDER_BASE_URL,
+        help='Base URL for constructing download links (default: ERDDAP OleanderXBT).'
     )
     parser.add_argument(
-        '--save_to', 
+        '--save_to',
         type=str,
-        help="Directory to save downloaded and unzipped files",
-        required=False, default=None
+        default=None,
+        help='Directory to save downloaded and unzipped files.'
     )
     parser.add_argument(
-        '--threads', 
-        type=int, 
-        default=4, 
+        '--threads',
+        type=int,
+        default=4,
         help='Number of threads to use for downloading.'
     )
     parser.add_argument(
-        '--dryrun', 
-        action='store_true', 
+        '--dryrun',
+        action='store_true',
         help='If set, no files are downloaded.'
     )
     parser.add_argument(
-        '--overwrite', 
-        action='store_true', 
+        '--overwrite',
+        action='store_true',
         help='If set, overwrite existing files.'
     )
     parser.add_argument(
         '--log_file',
         type=str,
-        default="oleanderXBT_download.log",
+        default='oleanderXBT_download.log',
         help='Path to log file (default: oleanderXBT_download.log).'
     )
 
     args = parser.parse_args()
 
-    # only pass through when provided
-    save_path = args.save_to
+    # --- Build URL list (OleanderXBT-specific logic stays in the script) ---
 
-    # extract all years to determine min and max years available
-    def extract_available_years(base_url):
-        try:
-            response = requests.get(base_url)
-            response.raise_for_status()
-            html_text = html.unescape(response.text)
-            year_matches = re.findall(r'(\d{4})_xbt_nc\.zip', html_text)
-            years = sorted(set(int(y) for y in year_matches if y.isdigit() and len(y) == 4))
-            return years
-        except requests.RequestException as e:
-            print(f"Error fetching directory listing: {e}")
-            return []
-    
-    min_year = min(extract_available_years(args.base_url))
-    max_year = max(extract_available_years(args.base_url))
+    available_years = DownloaderURLList.get_available_years(args.base_url)
 
-    # enforce minimum start_year
-    start_year = args.start_year
-    if start_year and start_year < min_year:
-        print(f"Warning: Start year {start_year} is before {min_year}. Adjusting to {min_year}.")
-        start_year = min_year
+    if not available_years:
+        print("Could not fetch available years from the server. Exiting.")
+        return
 
-    # determine list of URLs to download
-    if args.url_file: # read URLs from the provided file
+    min_year = min(available_years)
+    max_year = max(available_years)
+
+    if args.url_file:
         with open(args.url_file, 'r') as f:
             urls = [url.strip() for url in f if url.strip()]
 
-    elif start_year and args.end_year: # generate URLs for specified year range
+    elif args.start_year and args.end_year:
+        start_year = max(args.start_year, min_year)
+        if args.start_year < min_year:
+            print(f"Warning: start year {args.start_year} is before {min_year}. Adjusting.")
         years = range(start_year, args.end_year + 1)
-        urls = [f"{args.base_url}/{year}_xbt_nc.zip" for year in years]
+        urls = DownloaderURLList.build_urls(years, args.base_url)
 
-    else: # download all available years
-        print(f"\nWarning: No --url_file or --start_year/--end_year provided. "
-            f"Defaulting to download all OleanderXBT files ({min_year}-{max_year}).")
-
+    else:
+        print(
+            f"\nWarning: No --url_file or --start_year/--end_year provided. "
+            f"Defaulting to all available years ({min_year}-{max_year})."
+        )
         response = input("Do you want to continue? (y/N): ").strip().lower()
         if response != 'y':
             print("Download cancelled.")
             return
+        urls = DownloaderURLList.build_urls(available_years, args.base_url)
 
-        years = extract_available_years(args.base_url)
-        urls = [f"{args.base_url}/{year}_xbt_nc.zip" for year in years]
+    # --- Hand off to the downloader ---
 
-    config = {
-        'urls': urls,
-        'base_dir': save_path,
-        'log_file': args.log_file,
-        'num_threads': args.threads,
-        'overwrite': args.overwrite,
-        'dryrun': args.dryrun,
-    }
+    downloader = DownloaderURLList(
+        urls=urls,
+        log_file=args.log_file,
+        num_threads=args.threads,
+        overwrite=args.overwrite,
+        dryrun=args.dryrun,
+        base_dir=args.save_to,
+    )
 
-    print("Calling OleanderXBT downloader with the following configuration:")
-    pprint(config)
+    print(f"\nAttempting to download {len(urls)} files to: {downloader.base_dir}")
+    completed, failed = downloader.download()
 
-    print(f"\nAttempting to download from {len(urls)} URLs to: {save_path}")
-    
-    downloader = DownloaderURLList( **config )
-    downloader.url_list_download()
-
-    print("\nOleanderXBT download process finished.")
-    if config['dryrun']:
+    print("\nOleanderXBT download finished.")
+    if args.dryrun:
         print("Dry run complete. No files were actually downloaded.")
     else:
-        print(f"Review 'oleanderXBT_download.log' for details on the downloaded files.")
+        print(f"Success: {completed}  Failed: {failed}")
+        print(f"See '{args.log_file}' for details.")
 
 
 ##########################################################################
+
 if __name__ == "__main__":
+    print(datetime.now())
+    print()
     main()
+    print()
+    print(datetime.now())

--- a/scripts/download_oleanderXBT.py
+++ b/scripts/download_oleanderXBT.py
@@ -5,7 +5,7 @@
 # CLI for downloading OleanderXBT data.
 #
 ## @author David Nady <davidnady4yad@gmail.com>
-#         Refactored by mahi-anol
+#         Refactored by Mahi Sarwar Anol <anol.mahi@gmail.com>
 #
 ## @date Wed 23 Jul 2025
 


### PR DESCRIPTION
## Description

This PR implements the broader refactor of `downloaderOleanderXBT` as discussed on issue #44, following the three-layer architecture:

1. The **download script** parses CLI arguments and calls `downloader.download()`
2. The **dataset-specific downloader** (`DownloaderURLList`) handles OleanderXBT-specific logic: resolving available years from the ERDDAP server, building zip URLs, and deciding which files to skip
3. The **base `Downloader` class** provides all shared tools: `_download_file()`, `unzip_file()`, `_is_already_downloaded()`, and the new `download_parallel()` method

The key changes are:
- `download_parallel()` added to the base `Downloader` class, replacing `url_list_download()` in `downloaderOleanderXBT`
- `downloaderOleanderXBT` now contains only OleanderXBT-specific logic: `get_available_years()`, `build_urls()`, `_nc_files_exist()`, and `download()`
- `download_oleanderXBT.py` script is simplified to just parse arguments and call `downloader.download()`
- `unzip_file()`, `download_file()`, `zipfile`, and `shutil` imports removed from `downloaderOleanderXBT`

**Note:** During testing I found that `params.databases` in the `crocolakeloader` submodule was pointing to an older commit refered by the current develop branch. `params.databases` in `crocolakeloader/crocolakeloader/params.py` (line 19) lists `Oleander` but config.yaml uses `OleanderXBT` as the db name, which causes a `ValueError` in the base `Downloader.__init__`. The fix is to update the submodule reference to the latest `main` branch of `crocolakeloader` where `params.databases` already includes `OleanderXBT`.

### Fixes

Resolves issue #44.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other (refactor)

## How Has This Been Tested?

**Unit tests** (`crocolaketools/test/test_downloaderOleanderXBT.py`):
- Run with: `pytest crocolaketools/test/test_downloaderOleanderXBT.py -v`
- All 15 tests pass locally. Tests cover:
  - Default and custom constructor arguments
  - Correct inheritance from `Downloader`
  - `_nc_files_exist()` logic (files present, files absent, directory missing)
  - `get_available_years()` happy path and connection error
  - `build_urls()` correct URL construction
  - `download()` skip-if-present behaviour
  - `download()` downloads all when nothing present
  - `download()` with dryrun
  - `download()` with overwrite=True
  - `unzip_file()` called for each downloaded zip

**Integration test** (steps):
```bash
# Dryrun to verify URL building
python scripts/download_oleanderXBT.py --dryrun --start_year 2022 --end_year 2023

# Download a single year
python scripts/download_oleanderXBT.py --start_year 2022 --end_year 2022

# Verify skip-if-present
python scripts/download_oleanderXBT.py --start_year 2022 --end_year 2022

# Verify overwrite with parallel download
python scripts/download_oleanderXBT.py --start_year 2022 --end_year 2023 --overwrite

# Checking perquet conversion
python scripts/oleanderXBT2parquet.py --config
```

The download completed successfully, extracting NetCDF files into `crocolaketools/demo/demo_OleanderXBT_PHY/`.

## Checklist:

- [x] My code follows the [[contributing guidelines](https://github.com/enrico-mi/crocolaketools-public/blob/develop/CONTRIBUTE.md)](https://github.com/enrico-mi/crocolaketools-public/blob/develop/CONTRIBUTE.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned someone from the CrocoLake team to review this PR

## Comments

**Dependent changes:** The `crocolakeloader` submodule needed to be updated to its latest `main` commit to include `'OleanderXBT'` in `params.databases`. This is checked in as a submodule pointer update.
