### PR TITLE
[Feature] CI-workflow-to-sync-db-names-with-crocolakeloader

### DIFF
--- a/.github/workflows/sync-db-names.yml
+++ b/.github/workflows/sync-db-names.yml
@@ -1,0 +1,60 @@
+## @file sync-db-names.yml
+#
+## Implements the CI/CD part of boom-lab/crocolaketools#52.
+#
+## @author Mahi Sarwar Anol <anol.mahi@gmail.com>
+
+name: Sync db_names to CrocoLakeLoader
+
+# Opens a PR on boom-lab/crocolakeloader's `develop` branch whenever the
+# canonical database-name list (crocolaketools/db_names.py) changes on
+# crocolaketools' `develop` branch (i.e. when a PR is merged into develop).
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "crocolaketools/db_names.py"
+  workflow_dispatch: {}   # manual run button (always available)
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CrocoLakeTools (source)
+        uses: actions/checkout@v4
+        with:
+          path: crocolaketools
+
+      - name: Checkout CrocoLakeLoader (target)
+        uses: actions/checkout@v4
+        with:
+          repository: boom-lab/crocolakeloader
+          ref: develop          # <- target the loader's develop branch
+          token: ${{ secrets.CROCOLAKELOADER_SYNC_TOKEN }}
+          path: crocolakeloader
+
+      - name: Copy db_names.py into CrocoLakeLoader
+        run: |
+          cp crocolaketools/crocolaketools/db_names.py \
+             crocolakeloader/crocolakeloader/db_names.py
+
+      - name: Open / update sync PR on CrocoLakeLoader
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.CROCOLAKELOADER_SYNC_TOKEN }}
+          path: crocolakeloader
+          branch: sync/db-names
+          base: develop         # <- PR merges INTO develop
+          delete-branch: true
+          commit-message: "update: sync db_names.py from CrocoLakeTools"
+          title: "Sync db_names.py from CrocoLakeTools"
+          body: |
+            Automated sync of `crocolakeloader/db_names.py` from
+            **boom-lab/crocolaketools** (`crocolaketools/db_names.py`).
+
+            Triggered because the canonical database-name list changed on
+            crocolaketools' `develop`. `db_names.py` is auto-synced.


### PR DESCRIPTION
## Description

Added a github workflow that opens a PR on crocolakeloader repository whenever db_names.py changes on `develop` branch of crocolaketools, so the loader's copy stays in sync with crocolaketools.

### Fixes

Fixes #52 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (specify)

## How Has This Been Tested?

Need to figure out how it should be tested properly.

## Checklist:

- [ ] My code follows the [contributing guidelines](https://github.com/enrico-mi/crocolaketools-public/blob/develop/CONTRIBUTE.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned someone from the CrocoLake team to review this PR

## Comments

Pull request on crocolakeloader side got merged on develop branch(https://github.com/boom-lab/crocolakeloader/pull/10).

Once #53 (crocolaketools) gets merged then we can focus on  this PR.