### PR TITLE
[Feature] Enhancing erddap downloader with custom constraint controling

### DIFF
--- a/crocolaketools/config/config.yaml
+++ b/crocolaketools/config/config.yaml
@@ -102,19 +102,32 @@ IOOS_GLIDERS_PHY:
   num_threads: 4
   gated_parallel_download: True   # true = only one chunk in ERDDAP's heavy build phase at a time (avoids 503s)
                                   # false = all chunks fire immediately, bounded only by num_threads
-  # Optional constraints - all 7 ERDDAP tabledap operators type are supported:
-  #   =, !=, =~, <, <=, >, >=
-  # time>= / time<= clamp the chunking window so only data in the requested
-  # period is downloaded. All other constraints are sent to ERDDAP on every
-  # chunk request (applied server-side before data is transferred).
-  # Remove or comment out this block to download without any constraints.
+                  
   constraints:
+    # Optional constraints - all 7 ERDDAP tabledap operators type are supported:
+    #   =, !=, =~, <, <=, >, >=
+    # time>= / time<= clamp the chunking window so only data in the requested
+    # period is downloaded. All other constraints are sent to ERDDAP on every
+    # chunk request (applied server-side before data is transferred).
+    # Remove or comment out this block to download without any constraints.
+
+    # The variables we use in the constraint
+    # is expected to be available on the dataset. 
+    # So choose the variables carefully.)
     time>=: "2015-01-01T00:00:00Z"   # only download data from this date onward
     time<=: "2026-01-01T00:00:00Z"   # only download data up to this date
-    latitude>=:  -90.0               # regional constraints
+    # regional constraints
+    latitude>=:  -90.0              
     latitude<=:   90.0
     longitude>=: -180.0
     longitude<=:  180.0
+    # Example PHY constraints
+    pressure>=: 2.3
+    pressure<=: 150.3
+    depth>=: 100
+    depth<=: 300
+    # Example BGC constraints
+    chlorophyll<=: 20
 
 
 # Spray Gliders

--- a/crocolaketools/config/config.yaml
+++ b/crocolaketools/config/config.yaml
@@ -101,7 +101,21 @@ IOOS_GLIDERS_PHY:
   dryrun: false
   num_threads: 4
   gated_parallel_download: True   # true = only one chunk in ERDDAP's heavy build phase at a time (avoids 503s)
-                                   # false = all chunks fire immediately, bounded only by num_threads
+                                  # false = all chunks fire immediately, bounded only by num_threads
+  # Optional constraints - all 7 ERDDAP tabledap operators type are supported:
+  #   =, !=, =~, <, <=, >, >=
+  # time>= / time<= clamp the chunking window so only data in the requested
+  # period is downloaded. All other constraints are sent to ERDDAP on every
+  # chunk request (applied server-side before data is transferred).
+  # Remove or comment out this block to download without any constraints.
+  constraints:
+    time>=: "2015-01-01T00:00:00Z"   # only download data from this date onward
+    time<=: "2026-01-01T00:00:00Z"   # only download data up to this date
+    latitude>=:  -90.0               # regional constraints
+    latitude<=:   90.0
+    longitude>=: -180.0
+    longitude<=:  180.0
+
 
 # Spray Gliders
 SprayGliders_PHY:

--- a/crocolaketools/downloader/downloaderERDDAP.py
+++ b/crocolaketools/downloader/downloaderERDDAP.py
@@ -118,6 +118,15 @@ class DownloaderERDDAP(Downloader):
         # if False, chunk requests fire without the first-byte gate (see NoOpGate)
         self.gated_parallel_download = config.get("gated_parallel_download", True)
 
+        # Optional user-defined constraints from config.yaml.
+        # Supports all 7 ERDDAP tabledap operators: =, !=, =~, <, <=, >, >=
+        # time>= / time<= clamp the chunking window in _download_one.
+        # All other constraints are passed to ERDDAP on every chunk request.
+        _c = config.get("constraints", {})
+        self.time_start        = _c.pop("time>=", None)
+        self.time_end          = _c.pop("time<=", None)
+        self.extra_constraints = _c
+
         self._erddap = ERDDAP(
             server=self.server_url,
             protocol=self.protocol,
@@ -158,6 +167,8 @@ class DownloaderERDDAP(Downloader):
             constraints["time>="] = time_start.strftime(ERDDAP_TS_FMT)
         if time_end is not None:
             constraints["time<="] = time_end.strftime(ERDDAP_TS_FMT)
+
+        constraints.update(self.extra_constraints)
 
         return self._erddap.get_download_url(
             response=self.response_format,
@@ -386,6 +397,21 @@ class DownloaderERDDAP(Downloader):
             return False
 
         t_start, t_end = time_range
+
+        if self.time_start is not None:
+            user_t_start = datetime.strptime(self.time_start, ERDDAP_TS_FMT).replace(tzinfo=timezone.utc)
+            t_start = max(t_start, user_t_start)
+        if self.time_end is not None:
+            user_t_end = datetime.strptime(self.time_end, ERDDAP_TS_FMT).replace(tzinfo=timezone.utc)
+            t_end = min(t_end, user_t_end)
+
+        if t_start >= t_end:
+            logging.info(
+                "%s: dataset time range is outside the requested "
+                "constraint window - skipping.",
+                dataset_id,
+            )
+            return True
 
         for chunk_hours in CHUNK_SCHEDULE_HOURS:
             windows = self._split_window(t_start, t_end, chunk_hours=chunk_hours)

--- a/crocolaketools/downloader/downloaderERDDAP.py
+++ b/crocolaketools/downloader/downloaderERDDAP.py
@@ -24,7 +24,6 @@ import requests
 from requests.exceptions import ChunkedEncodingError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
-from tqdm import tqdm
 
 from crocolaketools.downloader.downloader import Downloader
 
@@ -315,26 +314,25 @@ class DownloaderERDDAP(Downloader):
         """
         tmp_path = local_path + ".tmp"
         try:
+            t0 = time.monotonic()
+            bytes_written = 0
             with requests.get(url, stream=True, timeout=HTTP_TIMEOUT) as response:
                 response.raise_for_status()
-                total_size = int(response.headers.get("content-length", 0))
                 signaled = False
-                with open(tmp_path, "wb") as fh, tqdm(
-                    desc=os.path.basename(local_path),
-                    total=total_size,
-                    unit="iB",
-                    unit_scale=True,
-                    unit_divisor=1024,
-                    leave=True,
-                ) as bar:
+                with open(tmp_path, "wb") as fh:
                     for chunk in response.iter_content(chunk_size=STREAM_CHUNK_SIZE):
                         if not signaled and chunk:
                             signaled = True
                             if on_first_byte is not None:
                                 on_first_byte()
-                        size = fh.write(chunk)
-                        bar.update(size)
+                        bytes_written += fh.write(chunk)
             os.replace(tmp_path, local_path)
+            logging.info(
+                "%s: %.1f MiB in %.1fs.",
+                os.path.basename(local_path),
+                bytes_written / 2**20,
+                time.monotonic() - t0,
+            )
         except Exception:
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
@@ -376,10 +374,6 @@ class DownloaderERDDAP(Downloader):
                     "%s%s - retrying in %ds (attempt %d/%d): %s",
                     type(last_exc).__name__, status_str, wait,
                     attempt + 1, MAX_RETRIES, url,
-                )
-                tqdm.write(
-                    f"  {type(last_exc).__name__}{status_str} - waiting {wait}s before retry "
-                    f"({attempt + 1}/{MAX_RETRIES})..."
                 )
                 time.sleep(wait)
 
@@ -483,6 +477,9 @@ class DownloaderERDDAP(Downloader):
                 "the first-byte gate.", dataset_id,
             )
 
+        # each outcome is logged here, in the worker thread, at the moment it
+        # happens; the as_completed loop below only tallies results, so log
+        # timestamps reflect the actual event times.
         def _worker(url: str, path: str, on_gate_release: Callable) -> None:
             try:
                 self._download_file_with_retry(
@@ -491,9 +488,22 @@ class DownloaderERDDAP(Downloader):
             except requests.exceptions.HTTPError as exc:
                 status = exc.response.status_code if exc.response is not None else None
                 if status == 404:
-                    tqdm.write(
-                        f"  {os.path.basename(path)}: empty window (no data) - skipped"
+                    logging.info(
+                        "%s: empty window (404, no data) - skipped.",
+                        os.path.basename(path),
                     )
+                elif status == 413:
+                    logging.warning(
+                        "%s: returned 413 - need smaller chunks.",
+                        os.path.basename(path),
+                    )
+                else:
+                    logging.error(
+                        "%s: failed: %s", os.path.basename(path), exc
+                    )
+                raise
+            except Exception as exc:
+                logging.error("%s: failed: %s", os.path.basename(path), exc)
                 raise
             finally:
                 on_gate_release()
@@ -511,6 +521,7 @@ class DownloaderERDDAP(Downloader):
                 future_to_path[future] = chunk_path
                 gate.wait()
 
+            # tally only; per-chunk outcomes were already logged by _worker
             for future in as_completed(future_to_path):
                 chunk_path = future_to_path[future]
                 try:
@@ -520,29 +531,12 @@ class DownloaderERDDAP(Downloader):
                     status = exc.response.status_code if exc.response is not None else None
                     if status == 404:
                         empty_chunks += 1
-                        logging.info(
-                            "%s: chunk %s returned 404 (empty window, no data) - skipping.",
-                            dataset_id, os.path.basename(chunk_path),
-                        )
-                    elif status == 413:
-                        got_413 = True
-                        failed_chunks += 1
-                        logging.warning(
-                            "%s: chunk %s returned 413 - need smaller chunks.",
-                            dataset_id, os.path.basename(chunk_path),
-                        )
                     else:
+                        if status == 413:
+                            got_413 = True
                         failed_chunks += 1
-                        logging.error(
-                            "%s: chunk %s failed: %s",
-                            dataset_id, os.path.basename(chunk_path), exc,
-                        )
-                except Exception as exc:
+                except Exception:
                     failed_chunks += 1
-                    logging.error(
-                        "%s: chunk %s failed: %s",
-                        dataset_id, os.path.basename(chunk_path), exc,
-                    )
 
         if not chunk_files:
             logging.error("%s: no chunks downloaded.", dataset_id)
@@ -562,12 +556,9 @@ class DownloaderERDDAP(Downloader):
                 "%s: %d empty window(s) skipped (404, no data).",
                 dataset_id, empty_chunks,
             )
-            tqdm.write(
-                f"  {dataset_id}: {empty_chunks} empty window(s) skipped, "
-                f"merging {len(chunk_files)} chunk(s)..."
-            )
-        else:
-            tqdm.write(f"  {dataset_id}: merging {len(chunk_files)} chunk(s)...")
+        logging.info(
+            "%s: merging %d chunk(s)...", dataset_id, len(chunk_files)
+        )
 
         return self._merge_chunks(chunk_files, local_path, dataset_id), got_413
 

--- a/crocolaketools/downloader/downloaderIOOSGliders.py
+++ b/crocolaketools/downloader/downloaderIOOSGliders.py
@@ -226,7 +226,6 @@ class DownloaderIOOSGliders(DownloaderERDDAP):
     ) -> str:
         """
         Build the tabledap parquet URL with per-dataset variable filtering.
-
         Queries the ERDDAP info endpoint first to find which variables this
         specific dataset actually carries, then intersects with GLIDER_VARIABLES.
         prevents 400 errors on datasets that lack some specific variables.
@@ -255,6 +254,9 @@ class DownloaderIOOSGliders(DownloaderERDDAP):
         if time_end is not None:
             constraints["time<="] = time_end.strftime("%Y-%m-%dT%H:%M:%SZ")
 
+        # merge in any extra constraints from config (spatial, variable-level, etc.)
+        constraints.update(self.extra_constraints)
+        
         # pass constraints explicitly, even as an empty dict, to avoid erddapy
         # falling back to self.constraints which may hold stale values from a
         # previous call

--- a/crocolaketools/test/test_downloaderIOOSGliders.py
+++ b/crocolaketools/test/test_downloaderIOOSGliders.py
@@ -353,6 +353,116 @@ class TestGatedParallelDownload:
         assert released.is_set(), "gate.wait() should unblock after callback fires"
 
 
+
+
+class TestConstraints:
+    """Tests for config.yaml constraint support in DownloaderERDDAP."""
+
+    def test_no_constraints_by_default(self, mock_base_downloader):
+        """time_start, time_end, extra_constraints are all None/empty by default."""
+        d = DownloaderIOOSGliders(config=dict(DUMMY_CONFIG))
+        assert d.time_start is None
+        assert d.time_end is None
+        assert d.extra_constraints == {}
+
+    def test_time_constraints_read_from_config(self, mock_base_downloader):
+        """time>= and time<= are parsed out of the constraints block."""
+        d = DownloaderIOOSGliders(config=dict(DUMMY_CONFIG, constraints={
+            "time>=": "2015-01-01T00:00:00Z",
+            "time<=": "2026-01-01T00:00:00Z",
+        }))
+        assert d.time_start == "2015-01-01T00:00:00Z"
+        assert d.time_end   == "2026-01-01T00:00:00Z"
+        assert d.extra_constraints == {}
+
+    def test_spatial_constraints_in_extra(self, mock_base_downloader):
+        """Spatial constraints land in extra_constraints."""
+        d = DownloaderIOOSGliders(config=dict(DUMMY_CONFIG, constraints={
+            "latitude>=":  -60.0,
+            "latitude<=":   60.0,
+            "longitude>=": -180.0,
+            "longitude<=":  180.0,
+        }))
+        assert d.extra_constraints == {
+            "latitude>=":  -60.0,
+            "latitude<=":   60.0,
+            "longitude>=": -180.0,
+            "longitude<=":  180.0,
+        }
+
+    def test_mixed_constraints_split_correctly(self, mock_base_downloader):
+        """time>=/time<= go to time_start/time_end; the rest go to extra_constraints."""
+        d = DownloaderIOOSGliders(config=dict(DUMMY_CONFIG, constraints={
+            "time>=":      "2020-01-01T00:00:00Z",
+            "latitude>=":  30.0,
+            "longitude<=": 10.0,
+        }))
+        assert d.time_start == "2020-01-01T00:00:00Z"
+        assert d.time_end is None
+        assert d.extra_constraints == {"latitude>=": 30.0, "longitude<=": 10.0}
+
+    def test_extra_constraints_merged_into_url(self, mock_base_downloader):
+        """extra_constraints are merged into the URL constraints dict."""
+        d = DownloaderIOOSGliders(config=dict(DUMMY_CONFIG, constraints={
+            "latitude>=": -60.0,
+            "latitude<=":  60.0,
+        }))
+        d.response_format = "parquet"
+        d._erddap = MagicMock()
+        with patch.object(DownloaderIOOSGliders, "get_dataset_variables",
+                          return_value=set()):
+            d.get_dataset_url("ru29-delayed")
+
+        called_constraints = d._erddap.get_download_url.call_args[1]["constraints"]
+        assert called_constraints["latitude>="] == -60.0
+        assert called_constraints["latitude<="] ==  60.0
+
+    def test_dataset_outside_time_window_skipped(self, tmp_path, mock_base_downloader):
+        """_download_one returns True (skip, not failure) when dataset is outside window."""
+        d = DownloaderIOOSGliders(config=dict(DUMMY_CONFIG, constraints={
+            "time>=": "2025-01-01T00:00:00Z",
+            "time<=": "2026-01-01T00:00:00Z",
+        }))
+        d.input_path = str(tmp_path) + "/"
+
+        # dataset range is entirely before the requested window
+        with patch.object(DownloaderIOOSGliders, "_get_dataset_time_range",
+                          return_value=(
+                              datetime(2010, 1, 1, tzinfo=timezone.utc),
+                              datetime(2012, 1, 1, tzinfo=timezone.utc),
+                          )), \
+             patch.object(DownloaderIOOSGliders, "_download_chunks_parallel") as mock_dl:
+            result = d._download_one("old-dataset-delayed", str(tmp_path / "out.parquet"))
+
+        assert result is True          # skipped, not failed
+        mock_dl.assert_not_called()    # nothing was downloaded
+
+    def test_dataset_partially_in_window_clamped(self, tmp_path, mock_base_downloader):
+        """_download_one clamps t_start/t_end to the requested window."""
+        d = DownloaderIOOSGliders(config=dict(DUMMY_CONFIG, constraints={
+            "time>=": "2021-06-01T00:00:00Z",
+        }))
+        d.input_path = str(tmp_path) + "/"
+
+        captured = {}
+
+        def fake_chunks(dataset_id, windows, tmp_dir, local_path):
+            captured["windows"] = windows
+            return True, False
+
+        with patch.object(DownloaderIOOSGliders, "_get_dataset_time_range",
+                          return_value=(
+                              datetime(2021, 1, 1, tzinfo=timezone.utc),
+                              datetime(2021, 12, 31, tzinfo=timezone.utc),
+                          )), \
+             patch.object(DownloaderIOOSGliders, "_download_chunks_parallel",
+                          side_effect=fake_chunks):
+            d._download_one("partial-delayed", str(tmp_path / "out.parquet"))
+
+        # first window must start at the clamped time_start, not the dataset start
+        assert captured["windows"][0][0] == datetime(2021, 6, 1, tzinfo=timezone.utc)
+
+
 ##########################################################################
 # Fixtures
 ##########################################################################


### PR DESCRIPTION
## Description

The `DownloaderERDDAP` class does not handle custom constraints that a user may want to apply while downloading datasets from a erddap server. A user may want to download datasets based on specific characteristics like region or may want to set the upper bound or lower bound for a specific numeric variable.

To add support for such scenario the `DownloaderERDDAP` class is enhanced with proper constraint handling in this PR. With this change, a user will be able to set their desired constraints from `config.yaml` file located at `crocolaketools/config/config.yaml`.

### Fixes

Fixes #55 .

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (specify)

## How Has This Been Tested?

- After applying the changes, constrained download was manually tasted.
```
python -m scripts.download_ioos_gliders --config
```
- unit tests related to constraints is added.
```
pytest crocolaketools/test/test_downloaderIOOSGliders.py::TestConstraints -v
```

## Checklist:

- [x] My code follows the [contributing guidelines](https://github.com/enrico-mi/crocolaketools-public/blob/develop/CONTRIBUTE.md) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned someone from the CrocoLake team to review this PR

## Comments
Example of how to apply custom constraints is given on [config.yaml](https://github.com/boom-lab/crocolaketools/pull/59/changes#diff-d850afd99482ded378b2b4b8a0d305119b57776e91c69ae02fb8077fbfc25262R105)
